### PR TITLE
URO-29 Added env variable support/defaults for PUBLIC_URL and REACT_APP_AUTH_SERIVCE_URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,8 @@
-EXTEND_ESLINT=true
+# Base URL path for the enviroment
+PUBLIC_URL = '/'
+
+# URL for the enviroment's Auth service
 REACT_APP_AUTH_SERIVCE_URL=https://ci.kbase.us/services/auth
+
+EXTEND_ESLINT=true
 SKIP_PREFLIGHT_CHECK=true

--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # Base URL path for the enviroment
-PUBLIC_URL = '/'
+PUBLIC_URL = '/dev/'
 
 # URL for the enviroment's Auth service
 REACT_APP_AUTH_SERIVCE_URL=https://ci.kbase.us/services/auth

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,8 +23,8 @@
   "root": true,
   "rules": {
     "max-len": ["error", { "code": 80 }],
-    "prettier/prettier": "warn",
-    "no-console": "warn",
+    "prettier/prettier": "error",
+    "no-console": "error",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/ban-types": "off"
   }

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -6,7 +6,7 @@ name: Build and Push to static-content
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -27,6 +27,9 @@ jobs:
           node-version: '16'
 
       - name: Run build
+        env:
+          PUBLIC_URL: 'https://next-dev.kbase.us/services/static'
+          REACT_APP_AUTH_SERIVCE_URL: 'https://next-dev.kbase.us/services/auth'
         run: npm install && npm run build
 
       - name: Push to repository

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run build
         env:
-          PUBLIC_URL: 'https://next-dev.kbase.us/services/static'
+          PUBLIC_URL: '/services/static'
           REACT_APP_AUTH_SERIVCE_URL: 'https://next-dev.kbase.us/services/auth'
         run: npm install && npm run build
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -25,7 +25,7 @@ export default function App() {
   }, [token]);
 
   return (
-    <Router>
+    <Router basename={process.env.PUBLIC_URL}>
       <div className={classes.container}>
         <div className={classes.left_navbar}>
           <LeftNavBar />


### PR DESCRIPTION
- adds a default `PUBLIC_URL` to `.env`
    - sidenote: this could be randomized during tests to help prevent accidental hard-coding of paths. @dakotablair thoughts?
- add `PUBLIC_URL` as the `react-router` `basename`, to ensure links work correctly
- add appropriate env variable values to the build action