### PR TITLE
Fix stylelint and align scss to standard.

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,6 +1,14 @@
 {
   "extends": "stylelint-config-sass-guidelines",
   "rules": {
+    "max-nesting-depth": 2,
+    "selector-class-pattern": [
+      "^[a-z0-9\\-_]+$",
+      {
+        "message": "Selector regex: ^[a-z0-9\\-_]+$ (selector-class-pattern)"
+      }
+    ],
+    "selector-no-qualifying-type": [true, { "ignore": ["class"] }],
     "string-quotes": "double"
   }
 }

--- a/scripts/lint.fix.sh
+++ b/scripts/lint.fix.sh
@@ -4,4 +4,4 @@ set -e
 set -x
 
 eslint . --ext=json,js,jsx,ts,tsx --fix
-stylelint --fix **/*.scss
+stylelint --fix '**/*.scss'

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -4,5 +4,5 @@ set -e
 set -x
 
 eslint .
-stylelint **/*.scss
+stylelint '**/*.scss'
 remark . --ext '.md,.mdx'

--- a/scripts/lint.strict.sh
+++ b/scripts/lint.strict.sh
@@ -4,5 +4,5 @@ set -e
 set -x
 
 eslint . --ext=json,js,jsx,ts,tsx --max-warnings=0
-stylelint **/*.scss
+stylelint '**/*.scss'
 remark . --ext '.md,.mdx' --frail

--- a/src/app/App.module.scss
+++ b/src/app/App.module.scss
@@ -1,34 +1,36 @@
+@import "../common/colors";
+
 .container {
-  height: 100vh;
-  width: 100vw;
-  position: relative;
+  align-content: flex-start;
+  align-items: stretch;
   display: flex;
   flex-flow: row wrap;
+  height: 100vh;
   justify-content: flex-start;
-  align-items: stretch;
-  align-content: flex-start;
+  position: relative;
+  width: 100vw;
 
   .left_navbar {
-    width: 75px;
+    background-color: use-color("white");
     flex-grow: 0;
     flex-shrink: 0;
-    background-color: white;
     position: relative;
+    width: 75px;
   }
 
   .page_content {
+    background-color: transparent;
     flex-grow: 1;
     flex-shrink: 1;
-    background-color: transparent;
     position: relative;
   }
 
   .topbar {
+    background-color: use-color("white");
     flex-grow: 0;
     flex-shrink: 0;
-    width: 100%;
     height: 70px;
-    background-color: white;
     position: relative;
+    width: 100%;
   }
 }

--- a/src/common/colors.scss
+++ b/src/common/colors.scss
@@ -127,43 +127,43 @@ $kbase-palette: (
 );
 
 $icons: (
-  // specialised use cases
-  "icon-app": map-get($kbase-palette, 'purple'),
-  "icon-generic": map-get($kbase-palette, 'silver'),
-  "icon-type": map-get($kbase-palette, 'black'),
+
+  "icon-app": map-get($kbase-palette, "purple"),
+  "icon-generic": map-get($kbase-palette, "silver"),
+  "icon-type": map-get($kbase-palette, "black"),
 );
 
 $kbase-palette: map-merge($kbase-palette, $icons);
 
 // Job status colors
-$job_status_colors: (
-  "created": map-get($kbase-palette, 'info'),
-  "estimating": map-get($kbase-palette, 'info'),
-  "queued": map-get($kbase-palette, 'info'),
-  "running": map-get($kbase-palette, 'info'),
-  "completed": map-get($kbase-palette, 'success-dark'),
-  "terminated": map-get($kbase-palette, 'warning-dark'),
-  // error already exists, but we need it in our job status list
-  "error": map-get($kbase-palette, 'error'),
-  "does_not_exist": map-get($kbase-palette, 'error'),
+$job-status-colors: (
+  "created": map-get($kbase-palette, "info"),
+  "estimating": map-get($kbase-palette, "info"),
+  "queued": map-get($kbase-palette, "info"),
+  "running": map-get($kbase-palette, "info"),
+  "completed": map-get($kbase-palette, "success-dark"),
+  "terminated": map-get($kbase-palette, "warning-dark"),
+
+  "error": map-get($kbase-palette, "error"),
+  "does_not_exist": map-get($kbase-palette, "error"),
 );
 
 $palette: map-merge($kbase-palette, $job_status_colors);
 
 // use a color from the palettes above
-@function use_color($key) {
+@function use-color($key) {
   @if map-has-key($kbase-palette, $key) {
     @return map-get($kbase-palette, $key);
   }
 
   @if not map-has-key($palette, $key) {
-    @warn 'Key `#{$key}` not found in $palette map.';
+    @warn "Key `#{$key}` not found in $palette map.";
   }
 
   @return map-get($palette, $key);
 }
 
 // use a color from the palettes above with the specified opacity
-@function use_rgba_color($key, $opacity) {
-  @return rgba(use_color($key), $opacity);
+@function use-rgba-color($key, $opacity) {
+  @return rgba(use-color($key), $opacity);
 }

--- a/src/features/layout/LeftNavBar.module.scss
+++ b/src/features/layout/LeftNavBar.module.scss
@@ -1,46 +1,46 @@
-@import '../../common/colors.scss';
+@import "../../common/colors";
 
 ul.nav_list {
-    list-style-type: none;
-    margin: 0;
-    padding: 3px 0 0 0;
-    width: 100%;
+  align-items: stretch;
+  display: flex;
+  flex-flow: column nowrap;
+  justify-content: flex-start;
+  list-style-type: none;
+  margin: 0;
+  padding: 3px 0 0;
+  width: 100%;
+
+  li.nav_item {
+    align-items: center;
+    background: use-color("white");
     display: flex;
     flex-flow: column nowrap;
-    align-items: stretch;
-    justify-content: flex-start;
+    margin: 3px 0;
+    padding: 3px;
+    text-align: center;
 
-    li.nav_item {
-      margin: 3px 0;
-      padding: 3px;
-      background: use_color('white');
-      text-align: center;
-      display: flex;
-      flex-flow: column nowrap;
-      align-items: center;
-
-      // Items contain links, so lets remove the default link styles
-      a {
-        text-decoration: none;
-        color: inherit;
-        font-size: inherit;
-      }
-
-      &.active {
-        background: use_rgba_color('silver', 0.5);
-      }
-
-      &:hover {
-        background: use_rgba_color('silver', 0.7);
-      }
-
-      .nav_icon {
-        width: 100%;
-        font-size: 42px;
-      }
-
-      .nav_desc {
-        font-size: 14px;
-      }
+    // Items contain links, so lets remove the default link styles
+    a {
+      color: inherit;
+      font-size: inherit;
+      text-decoration: none;
     }
+
+    &.active {
+      background: use-rgba-color("silver", 0.5);
+    }
+
+    &:hover {
+      background: use-rgba-color("silver", 0.7);
+    }
+
+    .nav_icon {
+      font-size: 42px;
+      width: 100%;
+    }
+
+    .nav_desc {
+      font-size: 14px;
+    }
+  }
 }

--- a/src/features/layout/TopBar.module.scss
+++ b/src/features/layout/TopBar.module.scss
@@ -1,18 +1,20 @@
-@import '../../common/colors.scss';
+@import "../../common/colors";
 
 .topbar {
-  display: flex;
   align-items: center;
-  justify-content: stretch;
   border-bottom: 5px solid #e0e0e0;
+  display: flex;
   height: 100%;
+  justify-content: stretch;
   position: relative;
+
   .topbar_item {
-    height: auto;
-    vertical-align: middle;
     flex-grow: 0;
     flex-shrink: 0;
+    height: auto;
     position: relative;
+    vertical-align: middle;
+
     &.stretch {
       flex-grow: 1;
       flex-shrink: 1;
@@ -22,46 +24,48 @@
 }
 
 .hamburger_menu {
+  color: use-color("mid-blue");
   font-size: 24px;
-  width: 53px;
-  text-align: center;
   height: 100%;
+  text-align: center;
   vertical-align: middle;
-  color: use_color('mid-blue');
+  width: 53px;
 }
 
 .page_title {
-  padding-left: 10px;
+  color: use-color("black");
   font-size: 2rem;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
   font-weight: bold;
-  color: use_color('black');
+  overflow: hidden;
+  padding-left: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .environment {
+  align-items: center;
   display: flex;
   flex-flow: column nowrap;
-  justify-content: center;
-  align-items: center;
   font-weight: bold;
+  justify-content: center;
   padding: 0 12px 0 5px;
-  &>svg {
+
+  >svg {
+    color: use-color("mid-blue");
     font-size: 2rem;
-    color: use_color('mid-blue');
   }
 }
 
 .login_menu {
-  height:100%;
-  width: 77px;
-  display: flex;
-  justify-content: center;
   align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  width: 77px;
+
   svg:first-of-type {
+    color: use-color("mid-blue");
     font-size: 2rem;
-    color: use_color('mid-blue');
     margin-right: 0.5em;
   }
 }

--- a/src/stories/styles/color-examples.scss
+++ b/src/stories/styles/color-examples.scss
@@ -1,32 +1,36 @@
-@import '../../common/colors.scss';
+@import "../../common/colors";
 
 @each $colorname, $_ in $palette {
   .example--#{$colorname} {
+    background-color: use-color($colorname);
+    border: 1px solid use-color("white");
     display: block;
     float: left;
-    background-color: use_color($colorname);
-    width: 150px;
-    height: 150px;
-    padding: 10px;
-    overflow: hidden;
-    border: 1px solid white;
     font-weight: bold;
+    height: 150px;
+    overflow: hidden;
+    padding: 10px;
     white-space: pre;
-    @if (lightness(use_color($colorname)) > 33) {
-      color: black;
+    width: 150px;
+    @if (lightness(use-color($colorname)) > 33) {
+      color: use-color("black");
     } @else {
-      color: white;
+      color: use-color("white");
     }
-    &::before, &::after {
-      content: '';
+
+    &::before,
+    &::after {
+      content: "";
       display: inline;
       font-weight: normal;
     }
+
     &::before {
       content: "'";
     }
+
     &::after {
-      content: "'\a#{use_color($colorname)}";
+      content: "'\a#{use-color($colorname)}";
     }
   }
 }

--- a/src/stories/styles/colors.stories.mdx
+++ b/src/stories/styles/colors.stories.mdx
@@ -7,8 +7,8 @@ import './color-examples.scss';
 # KBase Color Palette
 
 The following are the colors used in the KBase UI. They can be used within SCSS
-by importing `src/common/colors.scss` and using the `use_color($colorname)` or
-`use_rgba_color($colorname, $opacity)` functions.
+by importing `src/common/colors.scss` and using the `use-color($colorname)` or
+`use-rgba-color($colorname, $opacity)` functions.
 
 <div>
   <div className="example--orange">orange</div>


### PR DESCRIPTION
This PR fixes the stylelint scripts to correctly lint all scss files. Some configuration is added to grandfather in current practice, but this can be revisited in a later configuration change. The biggest conceptual change is that `use_color` and `use_rgba_color` are now named `use-color` and `use-rgba-color` respectively.