### PR TITLE
Updating  REACT_APP_AUTH_SERIVCE_URL

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run build
         env:
           PUBLIC_URL: '/services/static-content'
-          REACT_APP_AUTH_SERIVCE_URL: 'https://next-dev.kbase.us/services/auth'
+          REACT_APP_AUTH_SERIVCE_URL: 'https://ci.kbase.us/services/auth'
         run: npm install && npm run build
 
       - name: Push to repository


### PR DESCRIPTION
Updating to call CI for auth instead of next-dev, now that the content is running in CI.