### PR TITLE
URO-80: Add coverage directory to eslintigorne.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
-node_modules
 build
+coverage
+node_modules


### PR DESCRIPTION
The `lint:strict` script was behaving poorly because it was attempting to lint the coverage artifacts which it should not do.