### PR TITLE
Remove redundant line length rule.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,6 @@
   "plugins": ["@typescript-eslint", "prettier"],
   "root": true,
   "rules": {
-    "max-len": ["error", { "code": 80 }],
     "prettier/prettier": "warn",
     "no-console": "warn",
     "@typescript-eslint/explicit-module-boundary-types": "off",


### PR DESCRIPTION
Prettier will manage line length, and enabling the eslint `max-len` rule will cause conflicting messages in certain situations.