### PR TITLE
URO-52, URO-65 Add profile slice and component.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,9 @@
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
-        "@fortawesome/react-fontawesome": "^0.1.16",
+        "@fortawesome/react-fontawesome": "^0.1.18",
         "@kbase/narrative-utils": "^0.0.6",
+        "@redux-devtools/extension": "^3.2.2",
         "@reduxjs/toolkit": "^1.6.1",
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^11.2.7",
@@ -20,6 +21,7 @@
         "@types/node": "^12.20.17",
         "@types/react": "^17.0.15",
         "@types/react-dom": "^17.0.9",
+        "jest-fetch-mock": "^3.0.3",
         "node-sass": "^6.0.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -2679,8 +2681,7 @@
     },
     "node_modules/@kbase/narrative-utils": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@kbase/narrative-utils/-/narrative-utils-0.0.6.tgz",
-      "integrity": "sha512-z1qkCiUY4AQ93FyScZ7t9m2IUEdjKmKFYmNEILCdKy7xqZBFXCMcQqgwZXwvPgiQoTUjLmCrVARp28tN87V7tg==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "bluebird": "^3.5.3",
         "moment": "^2.24.0"
@@ -2942,6 +2943,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@redux-devtools/extension": {
+      "version": "3.2.2",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.0"
+      },
+      "peerDependencies": {
+        "redux": "^3.1.0 || ^4.0.0"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -9718,9 +9729,8 @@
     },
     "node_modules/boxen/node_modules/type-fest": {
       "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
       }
@@ -10134,12 +10144,18 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001271",
-      "license": "CC-BY-4.0",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001344",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -11142,6 +11158,13 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.5",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "2.6.7"
       }
     },
     "node_modules/cross-spawn": {
@@ -17064,6 +17087,14 @@
         "node": ">= 10.14.2"
       }
     },
+    "node_modules/jest-fetch-mock": {
+      "version": "3.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "node_modules/jest-get-type": {
       "version": "26.3.0",
       "license": "MIT",
@@ -20188,8 +20219,7 @@
     },
     "node_modules/moment": {
       "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
-      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -20332,14 +20362,21 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.5",
-      "dev": true,
+      "version": "2.6.7",
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-forge": {
@@ -22947,6 +22984,10 @@
       "version": "1.0.1",
       "license": "ISC"
     },
+    "node_modules/promise-polyfill": {
+      "version": "8.2.3",
+      "license": "MIT"
+    },
     "node_modules/promise.allsettled": {
       "version": "1.0.5",
       "dev": true,
@@ -24372,8 +24413,7 @@
     },
     "node_modules/read-pkg-up/node_modules/type-fest": {
       "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
       }
@@ -30436,7 +30476,6 @@
     },
     "node_modules/tr46": {
       "version": "0.0.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/trim": {
@@ -30593,8 +30632,7 @@
     },
     "node_modules/type-fest": {
       "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
       "optional": true,
       "peer": true,
       "engines": {
@@ -32073,7 +32111,6 @@
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
@@ -33121,7 +33158,6 @@
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -35133,8 +35169,6 @@
     },
     "@kbase/narrative-utils": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@kbase/narrative-utils/-/narrative-utils-0.0.6.tgz",
-      "integrity": "sha512-z1qkCiUY4AQ93FyScZ7t9m2IUEdjKmKFYmNEILCdKy7xqZBFXCMcQqgwZXwvPgiQoTUjLmCrVARp28tN87V7tg==",
       "requires": {
         "bluebird": "^3.5.3",
         "moment": "^2.24.0"
@@ -35289,6 +35323,12 @@
     "@popperjs/core": {
       "version": "2.10.2",
       "dev": true
+    },
+    "@redux-devtools/extension": {
+      "version": "3.2.2",
+      "requires": {
+        "@babel/runtime": "^7.17.0"
+      }
     },
     "@reduxjs/toolkit": {
       "version": "1.6.2",
@@ -39816,8 +39856,6 @@
         },
         "type-fest": {
           "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
           "dev": true
         }
       }
@@ -40106,7 +40144,7 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001271"
+      "version": "1.0.30001344"
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -40788,6 +40826,12 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-fetch": {
+      "version": "3.1.5",
+      "requires": {
+        "node-fetch": "2.6.7"
       }
     },
     "cross-spawn": {
@@ -44529,6 +44573,13 @@
         "jest-util": "^26.6.2"
       }
     },
+    "jest-fetch-mock": {
+      "version": "3.0.3",
+      "requires": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "jest-get-type": {
       "version": "26.3.0"
     },
@@ -46404,9 +46455,7 @@
       }
     },
     "moment": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
-      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
+      "version": "2.29.3"
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -46506,8 +46555,7 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.5",
-      "dev": true,
+      "version": "2.6.7",
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -48239,6 +48287,9 @@
     "promise-inflight": {
       "version": "1.0.1"
     },
+    "promise-polyfill": {
+      "version": "8.2.3"
+    },
     "promise.allsettled": {
       "version": "1.0.5",
       "dev": true,
@@ -49204,9 +49255,7 @@
           }
         },
         "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+          "version": "0.8.1"
         }
       }
     },
@@ -53076,8 +53125,7 @@
       }
     },
     "tr46": {
-      "version": "0.0.3",
-      "dev": true
+      "version": "0.0.3"
     },
     "trim": {
       "version": "0.0.1",
@@ -53174,8 +53222,6 @@
     },
     "type-fest": {
       "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
       "optional": true,
       "peer": true
     },
@@ -54128,8 +54174,7 @@
       "version": "1.1.2"
     },
     "webidl-conversions": {
-      "version": "3.0.1",
-      "dev": true
+      "version": "3.0.1"
     },
     "webpack": {
       "version": "4.44.2",
@@ -54851,7 +54896,6 @@
     },
     "whatwg-url": {
       "version": "5.0.0",
-      "dev": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
         "@kbase/narrative-utils": "^0.0.6",
-        "@redux-devtools/extension": "^3.2.2",
         "@reduxjs/toolkit": "^1.6.1",
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^11.2.7",
@@ -2943,16 +2942,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
-      }
-    },
-    "node_modules/@redux-devtools/extension": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.17.0"
-      },
-      "peerDependencies": {
-        "redux": "^3.1.0 || ^4.0.0"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -35323,12 +35312,6 @@
     "@popperjs/core": {
       "version": "2.10.2",
       "dev": true
-    },
-    "@redux-devtools/extension": {
-      "version": "3.2.2",
-      "requires": {
-        "@babel/runtime": "^7.17.0"
-      }
     },
     "@reduxjs/toolkit": {
       "version": "1.6.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/react-fontawesome": "^0.1.18",
     "@kbase/narrative-utils": "^0.0.6",
-    "@redux-devtools/extension": "^3.2.2",
     "@reduxjs/toolkit": "^1.6.1",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/react-fontawesome": "^0.1.18",
     "@kbase/narrative-utils": "^0.0.6",
+    "@redux-devtools/extension": "^3.2.2",
     "@reduxjs/toolkit": "^1.6.1",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
@@ -26,6 +27,7 @@
     "@types/node": "^12.20.17",
     "@types/react": "^17.0.15",
     "@types/react-dom": "^17.0.9",
+    "jest-fetch-mock": "^3.0.3",
     "node-sass": "^6.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -61,6 +63,9 @@
   },
   "engines": {
     "node": ">=16.13.0"
+  },
+  "jest": {
+    "resetMocks": false
   },
   "name": "ui-refresh-test",
   "private": true,

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -23,6 +23,6 @@ test('Auth page link works', () => {
   );
   const linkElement = screen.getByText(/Auth/i);
   linkElement.click();
-  const LoginStatusText = screen.getByText(/You are not logged in/i);
+  const LoginStatusText = screen.getByText(/kbase_session/);
   expect(LoginStatusText).toBeInTheDocument();
 });

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,21 +1,20 @@
 import classes from './App.module.scss';
 
-import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
 import { useAppDispatch } from '../common/hooks';
-import { useEffect } from 'react';
+import { FC, useEffect } from 'react';
 import { authFromToken } from '../features/auth/authSlice';
 import { setEnvironment } from '../features/layout/layoutSlice';
 import { getCookie } from '../common/cookie';
 
+import Routes from './Routes';
 import LeftNavBar from '../features/layout/LeftNavBar';
-import PageNotFound from '../features/layout/PageNotFound';
 import TopBar from '../features/layout/TopBar';
-
-import Navigator from '../features/navigator/Navigator';
-import Count from '../features/count/Counter';
-import Legacy from '../features/legacy/Legacy';
-import Auth from '../features/auth/Auth';
-import Status from '../features/status/Status';
+const UnauthenticatedView: FC = () => (
+  <>
+    Set your <var>kbase_session</var> cookie to your login token.
+  </>
+);
 
 export default function App() {
   const dispatch = useAppDispatch();
@@ -41,26 +40,7 @@ export default function App() {
           <LeftNavBar />
         </div>
         <div className={classes.page_content}>
-          <Switch>
-            <Route path="/legacy/*">
-              <Legacy />
-            </Route>
-            <Route path="/count">
-              <Count />
-            </Route>
-            <Route path="/auth">
-              <Auth />
-            </Route>
-            <Route path="/status">
-              <Status />
-            </Route>
-            <Route exact path="/">
-              <Navigator />
-            </Route>
-            <Route path="*">
-              <PageNotFound />
-            </Route>
-          </Switch>
+          {token ? <Routes /> : <UnauthenticatedView />}
         </div>
       </div>
     </Router>

--- a/src/app/Routes.tsx
+++ b/src/app/Routes.tsx
@@ -1,0 +1,42 @@
+import { FC } from 'react';
+import { Switch, Route } from 'react-router-dom';
+
+import Auth from '../features/auth/Auth';
+import Count from '../features/count/Counter';
+import Legacy from '../features/legacy/Legacy';
+import Navigator from '../features/navigator/Navigator';
+import PageNotFound from '../features/layout/PageNotFound';
+import ProfileWrapper from '../features/profile/Profile';
+
+const Routes: FC = () => (
+  <>
+    <Switch>
+      <Route path="/legacy/*">
+        <Legacy />
+      </Route>
+      <Route path="/profile/:usernameRequested/narratives">
+        <ProfileWrapper />
+      </Route>
+      <Route path="/profile/:usernameRequested">
+        <ProfileWrapper />
+      </Route>
+      <Route path="/profile">
+        <ProfileWrapper />
+      </Route>
+      <Route path="/count">
+        <Count />
+      </Route>
+      <Route path="/auth">
+        <Auth />
+      </Route>
+      <Route exact path="/">
+        <Navigator />
+      </Route>
+      <Route path="*">
+        <PageNotFound />
+      </Route>
+    </Switch>
+  </>
+);
+
+export default Routes;

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,24 +1,29 @@
 import { configureStore } from '@reduxjs/toolkit';
-import type { Meta } from '../common/types';
 import auth from '../features/auth/authSlice';
 import count from '../features/count/countSlice';
 import icons from '../common/slices/iconSlice';
 import layout from '../features/layout/layoutSlice';
 import profile from '../features/profile/profileSlice';
 
-const createStore = (preloadedState?: Meta) => {
+const createStore = () => {
   const config = {
     devTools: true,
-    preloadedState: preloadedState ? preloadedState : {},
     reducer: { auth, count, icons, layout, profile },
   };
   return configureStore(config);
 };
 
 export const store = createStore();
-export const createTestStore = (preloadedState?: Meta) =>
-  createStore(preloadedState);
 
 // Infer the `RootState` and `AppDispatch` types from the store itself
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;
+
+export const createTestStore = (preloadedState: Partial<RootState>) => {
+  const config = {
+    devTools: true,
+    preloadedState: preloadedState,
+    reducer: { auth, count, icons, layout, profile },
+  };
+  return configureStore(config);
+};

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,16 +1,23 @@
 import { configureStore } from '@reduxjs/toolkit';
-import count from '../features/count/countSlice';
+import type { Meta } from '../common/types';
 import auth from '../features/auth/authSlice';
-import layout from '../features/layout/layoutSlice';
+import count from '../features/count/countSlice';
 import icons from '../common/slices/iconSlice';
+import layout from '../features/layout/layoutSlice';
+import profile from '../features/profile/profileSlice';
 
-const createStore = () =>
-  configureStore({
-    reducer: { count, auth, layout, icons },
-  });
+const createStore = (preloadedState?: Meta) => {
+  const config = {
+    devTools: true,
+    preloadedState: preloadedState ? preloadedState : {},
+    reducer: { auth, count, icons, layout, profile },
+  };
+  return configureStore(config);
+};
 
 export const store = createStore();
-export const createTestStore = createStore;
+export const createTestStore = (preloadedState?: Meta) =>
+  createStore(preloadedState);
 
 // Infer the `RootState` and `AppDispatch` types from the store itself
 export type RootState = ReturnType<typeof store.getState>;

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,0 +1,13 @@
+/*
+ Meta is meant to be JSON-like and understandable to the typescript compiler.
+*/
+
+export interface Meta {
+  [key: string]:
+    | null
+    | boolean
+    | number
+    | string
+    | Array<null | boolean | number | string | Meta>
+    | Meta;
+}

--- a/src/features/layout/TopBar.tsx
+++ b/src/features/layout/TopBar.tsx
@@ -1,6 +1,3 @@
-import { FC } from 'react';
-import { useAppSelector } from '../../common/hooks';
-import classes from './TopBar.module.scss';
 import { FontAwesomeIcon as FAIcon } from '@fortawesome/react-fontawesome';
 import {
   faBars,
@@ -20,10 +17,15 @@ import {
   faUser,
   faWrench,
 } from '@fortawesome/free-solid-svg-icons';
-import { Dropdown } from '../../common/components';
+import { FC } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import logo from '../../common/assets/logo/46_square.png';
+import { Dropdown } from '../../common/components';
+import { useAppSelector } from '../../common/hooks';
+import { authUsername } from '../auth/authSlice';
+import { profileRealname } from '../profile/profileSlice';
+import classes from './TopBar.module.scss';
 
 export default function TopBar() {
   return (
@@ -48,6 +50,8 @@ export default function TopBar() {
 }
 
 const LoginMenu: FC = () => {
+  const username = useAppSelector(authUsername);
+  const realname = useAppSelector(profileRealname);
   const history = useHistory();
   return (
     <div className={classes.login_menu}>
@@ -61,8 +65,10 @@ const LoginMenu: FC = () => {
                 icon: undefined,
                 label: (
                   <div>
-                    <div>First Last</div>
-                    <div className={classes.login_menu_username}>username</div>
+                    <div>{realname}</div>
+                    <div className={classes.login_menu_username}>
+                      {username}
+                    </div>
                   </div>
                 ),
               },
@@ -71,7 +77,7 @@ const LoginMenu: FC = () => {
           {
             options: [
               {
-                value: '#your_profile',
+                value: '/profile',
                 icon: <FAIcon icon={faUser} />,
                 label: 'Your Profile',
               },

--- a/src/features/profile/Profile.module.scss
+++ b/src/features/profile/Profile.module.scss
@@ -1,0 +1,23 @@
+.narratives {
+  border: 1px dashed #000;
+}
+
+.narratives * {
+  border: 1px dashed #000;
+}
+
+.profile {
+  border: 1px dashed #000;
+}
+
+.profile * {
+  border: 1px dashed #000;
+}
+
+.profile-narratives {
+  border: 1px dashed #000;
+}
+
+.profile-nav {
+  border: 1px dashed #000;
+}

--- a/src/features/profile/Profile.test.tsx
+++ b/src/features/profile/Profile.test.tsx
@@ -1,0 +1,272 @@
+import { render, screen } from '@testing-library/react';
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock';
+import type { MockParams } from 'jest-fetch-mock';
+import React, { FC } from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter as Router } from 'react-router-dom';
+
+import {
+  initialState,
+  initialStateWithCache,
+  pendingProfile,
+  usernameRequested,
+  usernameOtherRequested,
+  realnameOther,
+  realname,
+} from './common';
+import {
+  Profile,
+  ProfileInfobox,
+  ProfileNarrativesMessage,
+  ProfileResume,
+  ProfileView,
+  ProfileWrapper,
+} from './Profile';
+
+import Routes from '../../app/Routes';
+import { createTestStore } from '../../app/store';
+import { authFromToken } from '../auth/authSlice';
+
+enableFetchMocks();
+
+const tokenResponseOK: [string, MockParams] = [
+  JSON.stringify({ user: usernameRequested }),
+  { status: 200 },
+];
+
+export const profileResponseOKFactory = (
+  username: string,
+  realname: string
+): [string, MockParams] => [
+  JSON.stringify({
+    version: '1.1',
+    result: [
+      [
+        {
+          user: {
+            username: username,
+            realname: realname,
+          },
+          profile: {},
+        },
+      ],
+    ],
+  }),
+  { status: 200 },
+];
+const profileResponseOK = profileResponseOKFactory(usernameRequested, realname);
+const profileResponseNoRealnameOK = profileResponseOKFactory(
+  usernameRequested,
+  ''
+);
+const profileOtherResponseOK = profileResponseOKFactory(
+  usernameOtherRequested,
+  realnameOther
+);
+let testStore = createTestStore(initialState);
+
+const consoleError = jest.spyOn(console, 'error');
+// This mockImplementation supresses console.error calls.
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+consoleError.mockImplementation(() => {});
+describe('Profile related components', () => {
+  afterAll(() => {
+    consoleError.mockRestore();
+  });
+
+  afterEach(() => {
+    consoleError.mockClear();
+  });
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    testStore = createTestStore(initialState);
+  });
+
+  test('renders Profile', () => {
+    render(
+      <Provider store={createTestStore()}>
+        <Router>
+          <Profile
+            narrativesLink={''}
+            pageTitle={''}
+            profileLink={''}
+            realname={''}
+            username={''}
+            viewMine={true}
+            viewNarratives={true}
+          />
+        </Router>
+      </Provider>
+    );
+  });
+
+  test('renders ProfileInfobox', () => {
+    render(<ProfileInfobox realname={realname} />);
+  });
+
+  test('renders ProfileNarrativesMessage for another user', () => {
+    render(<ProfileNarrativesMessage realname={realname} yours={false} />);
+  });
+
+  test('renders ProfileResume', () => {
+    render(<ProfileResume />);
+  });
+
+  test('renders ProfileView', () => {
+    render(<ProfileView realname={realname} />);
+  });
+
+  test('renders ProfileWrapper', () => {
+    render(
+      <Provider store={createTestStore()}>
+        <Router>
+          <ProfileWrapper />
+        </Router>
+      </Provider>
+    );
+    const linkElement = screen.getByText(/auth/i);
+    expect(linkElement).toBeInTheDocument();
+  });
+
+  test('renders ProfileWrapper for my profile', async () => {
+    fetchMock.mockResponses(tokenResponseOK, profileResponseOK);
+
+    await testStore.dispatch(authFromToken('a token'));
+    render(
+      <Provider store={testStore}>
+        <Router initialEntries={[`/profile`]}>
+          <Routes />
+        </Router>
+      </Provider>
+    );
+    await pendingProfile(testStore)();
+    const linkElement = screen.getByText(realname, { exact: false });
+    expect(linkElement).toBeInTheDocument();
+  });
+
+  test('renders ProfileWrapper for my profile, but no realname', async () => {
+    fetchMock.mockResponses(tokenResponseOK, profileResponseNoRealnameOK);
+
+    await testStore.dispatch(authFromToken('a token'));
+    render(
+      <Provider store={testStore}>
+        <Router initialEntries={[`/profile`]}>
+          <Routes />
+        </Router>
+      </Provider>
+    );
+    await pendingProfile(testStore)();
+    const linkElement = screen.getByText(/infobox/i);
+    expect(linkElement).toBeInTheDocument();
+  });
+
+  test('renders ProfileWrapper for another profile', async () => {
+    fetchMock.mockResponses(tokenResponseOK, profileOtherResponseOK);
+
+    await testStore.dispatch(authFromToken('a token'));
+    render(
+      <Provider store={testStore}>
+        <Router initialEntries={[`/profile/${usernameOtherRequested}`]}>
+          <Routes />
+        </Router>
+      </Provider>
+    );
+    await pendingProfile(testStore)();
+    const linkElement = screen.getByText(realnameOther, { exact: false });
+    expect(linkElement).toBeInTheDocument();
+  });
+
+  test('renders ProfileWrapper for usernameRequested', () => {
+    render(
+      <Provider store={createTestStore()}>
+        <Router initialEntries={[`/profile/${usernameRequested}`]}>
+          <Routes />
+        </Router>
+      </Provider>
+    );
+    const linkElement = screen.getByText(/auth/i);
+    expect(linkElement).toBeInTheDocument();
+  });
+
+  /* TODO: The tests marked `error` should check that console.error is called,
+   * but there is a subtle bug here. Waiting for a length of time causes an
+   * infinite loop of renders. It has to do with error handling in
+   * the ProfileWrapper component.
+   */
+  test('renders ProfileWrapper for viewUsername, logs an error', async () => {
+    render(
+      <Provider store={testStore}>
+        <Router initialEntries={[`/profile/${usernameRequested}`]}>
+          <Routes />
+        </Router>
+      </Provider>
+    );
+    const linkElement = screen.getByText(/user/i);
+    expect(linkElement).toBeInTheDocument();
+    // await (() => new Promise((resolve) => setTimeout(resolve, 10)))();
+    await Promise.resolve(true);
+  });
+
+  test('renders ProfileWrapper for a profile, logs an error', async () => {
+    const store = createTestStore();
+    fetchMock.mockResponses([
+      JSON.stringify({ user: usernameRequested }),
+      { status: 200 },
+    ]);
+
+    await store.dispatch(authFromToken('a token'));
+    render(
+      <Provider store={store}>
+        <Router initialEntries={[`/profile/${usernameRequested}`]}>
+          <Routes />
+        </Router>
+      </Provider>
+    );
+    const linkElement = screen.getByText(/profile/i);
+    expect(linkElement).toBeInTheDocument();
+  });
+
+  test('renders ProfileWrapper for a profile completely ', async () => {
+    const store = createTestStore();
+    fetchMock.mockResponses(
+      [JSON.stringify({ user: usernameRequested }), { status: 200 }],
+      profileResponseOK,
+      profileResponseOK
+    );
+    await store.dispatch(authFromToken('a token'));
+    const RoutesMock: jest.MockedFunction<FC> = jest.fn((props) => (
+      <Routes {...props} />
+    ));
+    render(
+      <Provider store={store}>
+        <Router initialEntries={[`/profile/${usernameRequested}`]}>
+          <RoutesMock />
+        </Router>
+      </Provider>
+    );
+    await pendingProfile(store)();
+    const linkElement = screen.getByText(realname, { exact: false });
+    expect(linkElement).toBeInTheDocument();
+    expect(RoutesMock.mock.calls[0].length).toBe(2);
+  });
+
+  test('renders ProfileWrapper for another cached profile completely ', async () => {
+    const store = createTestStore(initialStateWithCache);
+    fetchMock.mockResponses(
+      [JSON.stringify({ user: usernameRequested }), { status: 200 }],
+      profileOtherResponseOK,
+      profileOtherResponseOK
+    );
+    await store.dispatch(authFromToken('a token'));
+    render(
+      <Provider store={store}>
+        <Router initialEntries={[`/profile/${usernameOtherRequested}`]}>
+          <Routes />
+        </Router>
+      </Provider>
+    );
+    const linkElement = screen.getByText(realnameOther, { exact: false });
+    expect(linkElement).toBeInTheDocument();
+  });
+});

--- a/src/features/profile/Profile.tsx
+++ b/src/features/profile/Profile.tsx
@@ -19,6 +19,15 @@ import {
 } from './profileSlice';
 import classes from './Profile.module.scss';
 
+/*
+ * The following components are stubs due to be written in the future.
+ * NarrativesView
+ * ProfileInfobox
+ * ProfileNarrativesMessage
+ * ProfileResume
+ * ProfileView
+ */
+
 export const ProfileNarrativesMessage: FC<{
   realname: string;
   yours: boolean;
@@ -50,8 +59,6 @@ export const NarrativesView: FC<{ realname: string; yours: boolean }> = ({
         itemsRemaining={0}
         hasMoreItems={false}
         loading={false}
-        onLoadMoreItems={() => {}} //eslint-disable-line @typescript-eslint/no-empty-function
-        onSelectItem={() => {}} //eslint-disable-line @typescript-eslint/no-empty-function
         showVersionDropdown
       />
     </div>
@@ -162,7 +169,7 @@ export const ProfileWrapper: FC = () => {
   if (!profile) {
     return <>Loading user profile.</>;
   }
-  const profileNames = cachedProfiles[loadUsername].user;
+  const profileNames = profile.user;
   const realname = profileNames.realname;
   const whoseProfile = viewMine ? 'My ' : `${realname}'s `;
   const pageTitle = realname ? `${whoseProfile} Profile` : '';

--- a/src/features/profile/Profile.tsx
+++ b/src/features/profile/Profile.tsx
@@ -1,0 +1,186 @@
+import { FC } from 'react';
+import { Link, useLocation, useParams } from 'react-router-dom';
+import { Button } from '../../common/components';
+import NarrativeList from '../../common/components/NarrativeList/NarrativeList';
+import {
+  useAppDispatch,
+  useAppSelector,
+  usePageTitle,
+} from '../../common/hooks';
+import { authUsername } from '../auth/authSlice';
+import PageNotFound from '../layout/PageNotFound';
+import {
+  cache,
+  clearError,
+  error,
+  loadProfile,
+  selectUsername,
+  usernameSelected,
+} from './profileSlice';
+import classes from './Profile.module.scss';
+
+export const ProfileNarrativesMessage: FC<{
+  realname: string;
+  yours: boolean;
+}> = ({ realname, yours }) => {
+  if (yours) {
+    return <span>This table shows all of your narratives.</span>;
+  }
+  return (
+    <span>
+      This table shows all narratives owned by {realname} which are also
+      accessible to you.
+    </span>
+  );
+};
+
+export const ProfileResume: FC = () => {
+  return <div>Profile Resume</div>;
+};
+
+export const NarrativesView: FC<{ realname: string; yours: boolean }> = ({
+  realname,
+  yours,
+}) => {
+  return (
+    <div className={classes.narratives}>
+      <ProfileNarrativesMessage realname={realname} yours={yours} />
+      <NarrativeList
+        items={[]}
+        itemsRemaining={0}
+        hasMoreItems={false}
+        loading={false}
+        onLoadMoreItems={() => {}} //eslint-disable-line @typescript-eslint/no-empty-function
+        onSelectItem={() => {}} //eslint-disable-line @typescript-eslint/no-empty-function
+        showVersionDropdown
+      />
+    </div>
+  );
+};
+
+export const ProfileInfobox: FC<{ realname: string }> = ({ realname }) => {
+  return <div>Profile Infobox for {realname}.</div>;
+};
+
+export const ProfileView: FC<{ realname: string }> = ({ realname }) => {
+  return (
+    <div className={classes.profile}>
+      <ProfileInfobox realname={realname} />
+      <ProfileResume />
+    </div>
+  );
+};
+
+export interface ProfileParams {
+  narrativesLink: string;
+  pageTitle: string;
+  profileLink: string;
+  realname: string;
+  username: string;
+  viewMine: boolean;
+  viewNarratives: boolean;
+}
+
+export const Profile: FC<ProfileParams> = ({
+  narrativesLink,
+  pageTitle,
+  profileLink,
+  realname,
+  username,
+  viewMine,
+  viewNarratives,
+}) => {
+  usePageTitle(pageTitle);
+  return (
+    <>
+      <nav className={classes['profile-nav']}>
+        <ul className="links">
+          <li>
+            <Link to={profileLink}>Profile</Link>
+          </li>
+          <li>
+            <Link to={narrativesLink}>Narratives</Link>
+          </li>
+        </ul>
+      </nav>
+      <section className={classes['profile-narratives']}>
+        {viewNarratives ? (
+          <NarrativesView realname={realname} yours={viewMine} />
+        ) : (
+          <ProfileView realname={realname} />
+        )}
+        <Button>Edit</Button>
+      </section>
+    </>
+  );
+};
+
+export const ProfileWrapper: FC = () => {
+  const dispatch = useAppDispatch();
+  const cachedProfiles = useAppSelector(cache);
+  const errorMessage = useAppSelector(error);
+  const token = useAppSelector((state) => state.auth.token);
+  const usernameAuthed = useAppSelector(authUsername);
+  const tokenString = token ? token : '';
+  const location = useLocation();
+  const viewURL = location.pathname.split('/').slice(-1)[0];
+  const viewNarratives = viewURL === 'narratives';
+  const { usernameRequested } = useParams<{ usernameRequested: string }>();
+  // Was a username specified in the URL?
+  const usernameNotSpecified =
+    usernameRequested === 'narratives' || usernameRequested === undefined;
+  // Am I looking at my own profile?
+  const viewMine = usernameRequested === usernameAuthed || usernameNotSpecified;
+  // In any case, whose profile should be shown?
+  const viewUsername =
+    usernameAuthed && usernameNotSpecified ? usernameAuthed : usernameRequested;
+  const usernameSelectedState = useAppSelector(usernameSelected);
+  // If the username has not yet been selected.
+  if (usernameSelectedState !== viewUsername) {
+    dispatch(selectUsername(viewUsername));
+    return <>Loading</>;
+  }
+  // If there is an error, for now display Page Not Found.
+  if (errorMessage) {
+    // eslint-disable-next-line no-console
+    console.error(`Error message: ${errorMessage}`);
+    dispatch(clearError());
+    return <PageNotFound />;
+  }
+  if (!usernameAuthed) {
+    /* If this component is loaded first (eg. a full page refresh) then the
+        authentication state will need to be populated before displaying the
+        profile for the current user.
+    */
+    return <>Loading authentication state.</>;
+  }
+  const loadUsername = usernameNotSpecified ? usernameAuthed : viewUsername;
+  if (!(loadUsername in cachedProfiles)) {
+    dispatch(loadProfile({ token: tokenString, username: loadUsername }));
+  }
+  const profile = cachedProfiles[loadUsername];
+  if (!profile) {
+    return <>Loading user profile.</>;
+  }
+  const profileNames = cachedProfiles[loadUsername].user;
+  const realname = profileNames.realname;
+  const whoseProfile = viewMine ? 'My ' : `${realname}'s `;
+  const pageTitle = realname ? `${whoseProfile} Profile` : '';
+  const profileLink = viewMine ? '/profile/' : `/profile/${viewUsername}`;
+  const narrativesLink = viewMine
+    ? '/profile/narratives'
+    : `/profile/${viewUsername}/narratives`;
+  return (
+    <Profile
+      narrativesLink={narrativesLink}
+      pageTitle={pageTitle}
+      profileLink={profileLink}
+      realname={realname}
+      username={viewUsername}
+      viewMine={viewMine}
+      viewNarratives={viewNarratives}
+    />
+  );
+};
+
+export default ProfileWrapper;

--- a/src/features/profile/common.ts
+++ b/src/features/profile/common.ts
@@ -1,0 +1,63 @@
+import { EnhancedStore } from '@reduxjs/toolkit';
+import { pending, ProfileState } from './profileSlice';
+
+import type { Meta } from '../../common/types';
+
+export const realname = 'Rosalind Franklin';
+export const usernameRequested = 'rosalind-franklin';
+export const realnameOther = 'Dorothy Hodgkin';
+export const usernameOtherRequested = 'dorothy-hodgkin';
+
+export const initialState = {
+  auth: {
+    pending: false,
+    token: 'a token',
+    username: usernameRequested,
+  },
+  count: { count: 0 },
+  layout: { pageTitle: '', environment: 'unknown' },
+  profile: {
+    cache: {},
+    error: '',
+    realname: '',
+    usernameSelected: usernameRequested,
+  },
+};
+
+export const initialStateWithCache: Meta = {
+  auth: {
+    pending: false,
+    token: 'a token',
+    username: usernameRequested,
+  },
+  count: { count: 0 },
+  layout: { pageTitle: '', environment: 'unknown' },
+  profile: {
+    cache: {
+      [usernameOtherRequested]: {
+        user: {
+          username: usernameOtherRequested,
+          realname: realnameOther,
+        },
+        profile: {},
+      },
+    },
+    error: '',
+    pending: false,
+    realname: '',
+    usernameSelected: usernameRequested,
+  },
+};
+export const pendingProfileFactory = (store: EnhancedStore) => {
+  const profileIsPending = (resolve: (value: unknown) => void) => {
+    const profile = store.getState().profile as ProfileState;
+    const stillPending = pending({ profile });
+    stillPending
+      ? setTimeout(() => profileIsPending(resolve), 10)
+      : resolve(true);
+  };
+  return profileIsPending;
+};
+
+export const pendingProfile = (store: EnhancedStore) => () =>
+  new Promise((resolve) => pendingProfileFactory(store)(resolve));

--- a/src/features/profile/profileSlice.test.ts
+++ b/src/features/profile/profileSlice.test.ts
@@ -1,0 +1,72 @@
+// Start a new test file for profileSlice specifically.
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock';
+
+import { createTestStore } from '../../app/store';
+import {
+  initialStateWithCache,
+  pendingProfile,
+  usernameRequested,
+  usernameOtherRequested,
+  realnameOther,
+} from './common';
+import {
+  errMsgDefault,
+  errMsgKBase,
+  errMsgUsername,
+  errMsgUsernameParam,
+  loadProfile,
+  ProfileState,
+} from './profileSlice';
+
+enableFetchMocks();
+
+let testStore = createTestStore(initialStateWithCache);
+describe('The profileSlice async thunk loadProfile', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    testStore = createTestStore(initialStateWithCache);
+  });
+
+  test('uses cached profiles.', () => {
+    testStore.dispatch(
+      loadProfile({ token: '', username: usernameOtherRequested })
+    );
+    const cachedRealname = (testStore.getState().profile as ProfileState).cache[
+      usernameOtherRequested
+    ].user.realname;
+    expect(cachedRealname).toBe(realnameOther);
+  });
+
+  test('has a default error.', async () => {
+    testStore.dispatch({ type: loadProfile.rejected.type, payload: '' });
+    expect(testStore.getState().profile.error).toBe(errMsgDefault);
+  });
+
+  test('has an error for loading a profile without specifying a username.', async () => {
+    testStore.dispatch(loadProfile({ token: '', username: '' }));
+    await pendingProfile(testStore)();
+    expect(testStore.getState().profile.error).toBe(errMsgUsername);
+  });
+
+  test('has an error for http response errors.', async () => {
+    fetchMock.mockResponses([JSON.stringify({}), { status: 500 }]);
+    testStore.dispatch(loadProfile({ token: '', username: usernameRequested }));
+    await pendingProfile(testStore)();
+    expect(testStore.getState().profile.error).toBe(errMsgKBase);
+  });
+
+  test('has an error for malformed response body errors.', async () => {
+    fetchMock.mockResponses([
+      JSON.stringify({
+        version: '1.1',
+        result: [[]],
+      }),
+      { status: 200 },
+    ]);
+    testStore.dispatch(loadProfile({ token: '', username: usernameRequested }));
+    await pendingProfile(testStore)();
+    expect(testStore.getState().profile.error).toBe(
+      errMsgUsernameParam(usernameRequested)
+    );
+  });
+});

--- a/src/features/profile/profileSlice.ts
+++ b/src/features/profile/profileSlice.ts
@@ -127,6 +127,7 @@ export const profileSlice = createSlice({
         state.usernameSelected = user.username;
         const cache: KBaseProfileResponseCache = {
           [state.usernameSelected]: profileCache,
+          ...state.cache,
         };
         state.cache = cache;
         state.pending = false;

--- a/src/features/profile/profileSlice.ts
+++ b/src/features/profile/profileSlice.ts
@@ -1,0 +1,161 @@
+import { KBaseJsonRpcError, KBaseServiceClient } from '@kbase/narrative-utils';
+import {
+  ActionReducerMapBuilder,
+  createSlice,
+  createAsyncThunk,
+} from '@reduxjs/toolkit';
+import type { Meta } from '../../common/types';
+
+export const errMsgDefault = 'Error loading profile.';
+export const errMsgUsername = 'No username specified.';
+export const errMsgUsernameParam = (username: string) =>
+  `Error loading profile for ${username}.`;
+export const errMsgKBase = 'Error contacting KBase services.';
+
+interface KBaseProfileUser extends Meta {
+  username: string;
+  realname: string;
+}
+
+interface KBaseProfileResponse extends Meta {
+  user: KBaseProfileUser;
+  profile: Meta;
+}
+
+interface KBaseProfileResponseCache extends Meta {
+  [user: string]: KBaseProfileResponse;
+}
+
+// Define a type for the slice state
+export interface ProfileState extends Meta {
+  cache: KBaseProfileResponseCache;
+  error: string;
+  pending: boolean;
+  realname: string;
+  usernameSelected: string | null;
+}
+
+const initialState: ProfileState = {
+  cache: {},
+  error: '',
+  pending: false,
+  realname: '',
+  usernameSelected: null,
+};
+
+const nullProfileFactory = (username: string): KBaseProfileResponseCache => ({
+  profile: {
+    user: {
+      username,
+      realname: '',
+    },
+    profile: {},
+  },
+});
+
+interface LoadProfileParams {
+  token: string;
+  username?: string;
+}
+
+export const loadProfiles = async (token: string, usernames: string[]) => {
+  const client = new KBaseServiceClient({
+    module: 'UserProfile',
+    url: 'https://ci.kbase.us/services/user_profile/rpc',
+    authToken: token,
+  });
+  const profiles = await client.call('get_user_profile', [usernames]);
+  return profiles;
+};
+
+export const cache = ({ profile }: { profile: ProfileState }) => profile.cache;
+export const loadProfile = createAsyncThunk(
+  'profile/loadProfile',
+  async (
+    { token, username }: LoadProfileParams,
+    { getState, rejectWithValue }
+  ): Promise<KBaseProfileResponseCache> => {
+    if (!username) throw new Error(errMsgUsername);
+    const profilesCached = cache(getState() as { profile: ProfileState });
+    if (username in profilesCached) {
+      return { profile: profilesCached[username] };
+    }
+    let profiles;
+    try {
+      profiles = await loadProfiles(token, [username]);
+    } catch (err) {
+      if (err instanceof KBaseJsonRpcError) {
+        throw new Error(errMsgKBase);
+      }
+      throw err;
+    }
+    const profile: KBaseProfileResponse = profiles[0];
+    if (!profile) {
+      return Promise.reject(
+        rejectWithValue({
+          username,
+          error: `Username '${username}' does not exist.`,
+        })
+      );
+    }
+    return { profile };
+  }
+);
+
+export const profileSlice = createSlice({
+  name: 'profile',
+  initialState,
+  reducers: {
+    clearError: (state) => {
+      state.error = '';
+    },
+    selectUsername: (state, action) => {
+      state.usernameSelected = action.payload;
+    },
+  },
+  extraReducers: (builder): ActionReducerMapBuilder<ProfileState> =>
+    builder
+      .addCase(loadProfile.pending, (state) => {
+        state.error = '';
+        state.pending = true;
+      })
+      .addCase(loadProfile.fulfilled, (state, action) => {
+        const { profile: profileCache } =
+          action.payload as KBaseProfileResponseCache;
+        const { user } = profileCache;
+        state.realname = user.realname;
+        state.usernameSelected = user.username;
+        const cache: KBaseProfileResponseCache = {
+          [state.usernameSelected]: profileCache,
+        };
+        state.cache = cache;
+        state.pending = false;
+      })
+      .addCase(loadProfile.rejected, (state, action) => {
+        const payload = action.payload as Record<string, string>;
+        state.pending = false;
+        state.usernameSelected = null;
+        const errMsg =
+          action.error && action.error.message
+            ? action.error.message
+            : errMsgDefault;
+        if (!payload) {
+          state.error = errMsg;
+          return;
+        }
+        const username = payload.username;
+        state.cache[username] = nullProfileFactory(username).profile;
+        state.error = `Error loading profile for ${username}.`;
+        state.realname = '';
+      }),
+});
+
+export default profileSlice.reducer;
+export const { clearError, selectUsername } = profileSlice.actions;
+export const error = ({ profile }: { profile: ProfileState }) => profile.error;
+export const pending = ({ profile }: { profile: ProfileState }) =>
+  profile.pending;
+export const profileRealname = ({ profile }: { profile: ProfileState }) =>
+  profile.realname;
+export const usernameSelected = ({ profile }: { profile: ProfileState }) =>
+  profile.usernameSelected;

--- a/src/stories/components/Profile.stories.tsx
+++ b/src/stories/components/Profile.stories.tsx
@@ -1,0 +1,50 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { BrowserRouter as Router } from 'react-router-dom';
+
+import { Profile, ProfileParams } from '../../features/profile/Profile';
+
+export default {
+  title: 'Components/Profile',
+  component: Profile,
+} as ComponentMeta<typeof Profile>;
+
+// Using a template allows the component to be rendered with dynamic storybook
+// controls (args) these can be used to dynamically change the props of the
+// component e.g. `<Component {...args} />`
+const ProfileTemplate: ComponentStory<typeof Profile> = (args) => {
+  const {
+    narrativesLink,
+    pageTitle,
+    profileLink,
+    realname,
+    username,
+    viewMine,
+    viewNarratives,
+  } = args as ProfileParams;
+  return (
+    <Router>
+      <Profile
+        narrativesLink={narrativesLink}
+        pageTitle={pageTitle}
+        profileLink={profileLink}
+        realname={realname}
+        username={username}
+        viewMine={viewMine}
+        viewNarratives={viewNarratives}
+      />
+    </Router>
+  );
+};
+
+// Each story for the component can then reuse the template, setting props with
+// the "args" attribute
+export const Default = ProfileTemplate.bind({});
+Default.args = {
+  narrativesLink: '/profile/narratives',
+  pageTitle: 'Some profile',
+  profileLink: '/profile',
+  realname: 'Some Realname',
+  username: 'someusername',
+  viewMine: true,
+  viewNarratives: false,
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "module": "esnext",
     "moduleResolution": "node",
     "noEmit": true,


### PR DESCRIPTION
URO-52 Profile component: This commit introduces <ProfileWrapper /> to manage state of profile view. The <Profile /> component is mostly a template and holds very little logic, but handles passing the profile data to the profile view and
the narrative view.

URO-65 Profile slice: The new profile slice holds all data which is visible in the profile view. This commit introduces an ad-hoc caching layer for profile data. It retrieves data from the profile service using @kbase/narrative-utils.

This commit also includes the Meta type to avoid explicitly typing portions of service call responses not currently implemented. It factors <Routes /> into its own module and adds jest-fetch-mock for testing HTTP requests.