### PR TITLE
React router v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-redux": "^7.2.4",
-        "react-router-dom": "^5.2.0",
+        "react-router-dom": "^6.3.0",
         "react-scripts": "4.0.3",
         "react-select": "^5.2.2",
         "timeago.js": "^4.0.2",
@@ -15161,6 +15161,14 @@
         "node": "*"
       }
     },
+    "node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "license": "MIT",
@@ -19982,18 +19990,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/mini-create-react-context": {
-      "version": "0.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.1",
-        "tiny-warning": "^1.0.3"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.0.0",
-        "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/mini-css-extract-plugin": {
       "version": "0.11.3",
       "license": "MIT",
@@ -23792,78 +23788,28 @@
       }
     },
     "node_modules/react-router": {
-      "version": "5.2.1",
-      "license": "MIT",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.4.0",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "history": "^5.2.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "5.3.0",
-      "license": "MIT",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.2.1",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
-    },
-    "node_modules/react-router-dom/node_modules/history": {
-      "version": "4.10.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
-    "node_modules/react-router/node_modules/history": {
-      "version": "4.10.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
-    "node_modules/react-router/node_modules/isarray": {
-      "version": "0.0.1",
-      "license": "MIT"
-    },
-    "node_modules/react-router/node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
-    "node_modules/react-router/node_modules/react-is": {
-      "version": "16.13.1",
-      "license": "MIT"
     },
     "node_modules/react-scripts": {
       "version": "4.0.3",
@@ -27574,10 +27520,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "license": "MIT"
-    },
     "node_modules/resolve-url": {
       "version": "0.2.1",
       "license": "MIT"
@@ -30339,14 +30281,6 @@
       "version": "0.3.0",
       "license": "MIT"
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.1.0",
-      "license": "MIT"
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "license": "MIT"
-    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "license": "BSD-3-Clause"
@@ -31576,10 +31510,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -43405,6 +43335,14 @@
       "version": "10.7.3",
       "dev": true
     },
+    "history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "requires": {
@@ -46298,13 +46236,6 @@
     "min-indent": {
       "version": "1.0.1"
     },
-    "mini-create-react-context": {
-      "version": "0.4.1",
-      "requires": {
-        "@babel/runtime": "^7.12.1",
-        "tiny-warning": "^1.0.3"
-      }
-    },
     "mini-css-extract-plugin": {
       "version": "0.11.3",
       "requires": {
@@ -48807,68 +48738,20 @@
       "peer": true
     },
     "react-router": {
-      "version": "5.2.1",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
       "requires": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.4.0",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "dependencies": {
-        "history": {
-          "version": "4.10.1",
-          "requires": {
-            "@babel/runtime": "^7.1.2",
-            "loose-envify": "^1.2.0",
-            "resolve-pathname": "^3.0.0",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0",
-            "value-equal": "^1.0.1"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1"
-        },
-        "path-to-regexp": {
-          "version": "1.8.0",
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        },
-        "react-is": {
-          "version": "16.13.1"
-        }
+        "history": "^5.2.0"
       }
     },
     "react-router-dom": {
-      "version": "5.3.0",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
       "requires": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.2.1",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "dependencies": {
-        "history": {
-          "version": "4.10.1",
-          "requires": {
-            "@babel/runtime": "^7.1.2",
-            "loose-envify": "^1.2.0",
-            "resolve-pathname": "^3.0.0",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0",
-            "value-equal": "^1.0.1"
-          }
-        }
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
       }
     },
     "react-scripts": {
@@ -51169,9 +51052,6 @@
     "resolve-from": {
       "version": "5.0.0"
     },
-    "resolve-pathname": {
-      "version": "3.0.0"
-    },
     "resolve-url": {
       "version": "0.2.1"
     },
@@ -53037,12 +52917,6 @@
     "timsort": {
       "version": "0.3.0"
     },
-    "tiny-invariant": {
-      "version": "1.1.0"
-    },
-    "tiny-warning": {
-      "version": "1.0.3"
-    },
     "tmpl": {
       "version": "1.0.5"
     },
@@ -53812,9 +53686,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "value-equal": {
-      "version": "1.0.1"
     },
     "vary": {
       "version": "1.1.2"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.4",
-    "react-router-dom": "^5.2.0",
+    "react-router-dom": "^6.3.0",
     "react-scripts": "4.0.3",
     "react-select": "^5.2.2",
     "timeago.js": "^4.0.2",

--- a/src/app/Routes.tsx
+++ b/src/app/Routes.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { Switch, Route } from 'react-router-dom';
+import { Route, Routes as RRRoutes } from 'react-router-dom';
 
 import Auth from '../features/auth/Auth';
 import Count from '../features/count/Counter';
@@ -10,32 +10,22 @@ import ProfileWrapper from '../features/profile/Profile';
 
 const Routes: FC = () => (
   <>
-    <Switch>
-      <Route path="/legacy/*">
-        <Legacy />
-      </Route>
-      <Route path="/profile/:usernameRequested/narratives">
-        <ProfileWrapper />
-      </Route>
-      <Route path="/profile/:usernameRequested">
-        <ProfileWrapper />
-      </Route>
-      <Route path="/profile">
-        <ProfileWrapper />
-      </Route>
-      <Route path="/count">
-        <Count />
-      </Route>
-      <Route path="/auth">
-        <Auth />
-      </Route>
-      <Route exact path="/">
-        <Navigator />
-      </Route>
-      <Route path="*">
-        <PageNotFound />
-      </Route>
-    </Switch>
+    <RRRoutes>
+      <Route path="/legacy/*" element={Legacy} />
+      <Route
+        path="/profile/:usernameRequested/narratives"
+        element={<ProfileWrapper />}
+      />
+      <Route path="/profile/:usernameRequested" element={<ProfileWrapper />} />
+      <Route path="/profile" element={<ProfileWrapper />} />
+      <Route path="/count" element={<Count />} />
+      <Route path="/auth" element={<Auth />} />
+      <Route path={'/:id/:obj/:ver'} element={<Navigator />} />
+      <Route path={'/:category'} element={<Navigator />} />
+      <Route path={'/:category/:id/:obj/:ver'} element={<Navigator />} />
+      <Route path="/" element={<Navigator />} />
+      <Route path="*" element={<PageNotFound />} />
+    </RRRoutes>
   </>
 );
 

--- a/src/features/layout/PageNotFound.tsx
+++ b/src/features/layout/PageNotFound.tsx
@@ -1,7 +1,11 @@
-export default function PageNotFound() {
-  return (
+import { FC } from 'react';
+
+const PageNotFound: FC = () => (
+  <>
     <section>
       <h2>Page Not Found.</h2>
     </section>
-  );
-}
+  </>
+);
+
+export default PageNotFound;

--- a/src/features/layout/TopBar.tsx
+++ b/src/features/layout/TopBar.tsx
@@ -18,7 +18,7 @@ import {
   faWrench,
 } from '@fortawesome/free-solid-svg-icons';
 import { FC } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import logo from '../../common/assets/logo/46_square.png';
 import { Dropdown } from '../../common/components';
@@ -52,7 +52,7 @@ export default function TopBar() {
 const LoginMenu: FC = () => {
   const username = useAppSelector(authUsername);
   const realname = useAppSelector(profileRealname);
-  const history = useHistory();
+  const navigate = useNavigate();
   return (
     <div className={classes.login_menu}>
       <Dropdown
@@ -99,7 +99,7 @@ const LoginMenu: FC = () => {
           },
         ]}
         onChange={(opt) => {
-          if (opt?.[0]) history.push(opt[0].value as string);
+          if (opt?.[0]) navigate(opt[0].value as string);
         }}
       >
         <div className={classes.login_menu_button}>

--- a/src/features/legacy/Legacy.tsx
+++ b/src/features/legacy/Legacy.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 /** Creates and manages an iframe for any legacy KBaseUI page,
  * modifies the history to point to the iframe's path,
@@ -9,15 +9,15 @@ import { useHistory } from 'react-router-dom';
  * TODO: extract title from iframe topbar and set it as the page title.
  */
 export default function Legacy() {
-  const history = useHistory();
+  const location = useLocation();
+  const navigate = useNavigate();
 
   const legacyContent = useRef<HTMLIFrameElement>(null);
   const legacyFrame = legacyContent?.current?.contentWindow;
   const pathSyncInterval = 200;
 
   // path state
-  const initPath =
-    legacyPart(history.location.pathname) + history.location.hash;
+  const initPath = legacyPart(location.pathname) + location.hash;
   const [initialLegacyPath, setInitialLegacyPath] = useState<string>(initPath);
   const [legacyPath, setLegacyPath] = useState<string>(initPath);
   const [badLegacyPath, setBadLegacyPath] = useState<boolean>(false);
@@ -59,7 +59,7 @@ export default function Legacy() {
         if (inner !== legacyPath) {
           setLegacyPath(inner);
           pathChanged = true;
-          history.push(`/legacy${inner}`);
+          navigate(`/legacy${inner}`);
         } else if (outer !== legacyPath) {
           setLegacyPath(outer);
           setInitialLegacyPath(outer);
@@ -78,7 +78,7 @@ export default function Legacy() {
     return () => {
       clearInterval(pathAndHeightSync);
     };
-  }, [history, legacyContent, legacyPath, legacyHeight]);
+  }, [navigate, legacyContent, legacyPath, legacyHeight]);
 
   // This effect recursively injects <base target="_top"> into all child
   // iframe's `<head>` tags. this is necessary to allow the iframe to navigate


### PR DESCRIPTION
This PR updates usage of React Router to v6. I mostly followed the [instructions in the official guide](https://github.com/remix-run/react-router/discussions/8753), but the project is small enough at this point that I skipped using the `react-router-dom-v5-compat` package.

Please double check [this line](https://github.com/kbase/ui-refresh-test/pull/48/files#diff-b7d533292606d4bca64b9e33f402524c5cf5e62d893fb457d9ff8f65843756daL19-R20) and make sure it is still doing what is expected.

This PR is built on top of #46 but it can be interchanged if necessary. [Here is the diff](https://github.com/kbase/ui-refresh-test/compare/rtk_query_api...react-router-v6) of changes from that PR's branch