### PR TITLE
URO-149 Connect data and preview views to API

### DIFF
--- a/src/common/api/searchApi.ts
+++ b/src/common/api/searchApi.ts
@@ -1,6 +1,6 @@
 import { baseApi } from './index';
 import { jsonRpcService } from './utils/serviceHelpers';
-import { NarrativeListDoc } from '../types/NarrativeDoc';
+import { NarrativeDoc } from '../types/NarrativeDoc';
 
 const searchService = jsonRpcService({
   url: '/services/searchapi2/rpc',
@@ -32,7 +32,7 @@ interface SearchGetNarrativesParams {
 
 interface SearchGetNarrativesResults {
   count: number;
-  hits: NarrativeListDoc[];
+  hits: NarrativeDoc[];
   search_time: number;
 }
 
@@ -48,7 +48,7 @@ export const searchApi = baseApi
   .enhanceEndpoints({ addTagTypes: ['Search'] })
   .injectEndpoints({
     endpoints: (builder) => ({
-      getSearch: builder.query<
+      getNarratives: builder.query<
         SearchResults['getNarratives'],
         SearchParams['getNarratives']
       >({
@@ -62,5 +62,5 @@ export const searchApi = baseApi
     }),
   });
 
-export const { getSearch } = searchApi.endpoints;
+export const { getNarratives } = searchApi.endpoints;
 export const clearCacheAction = searchApi.util.invalidateTags(['Search']);

--- a/src/common/api/workspaceApi.ts
+++ b/src/common/api/workspaceApi.ts
@@ -1,3 +1,4 @@
+import { Cell } from '../types/NarrativeDoc';
 import { baseApi } from './index';
 import { jsonRpcService } from './utils/serviceHelpers';
 
@@ -15,6 +16,7 @@ type TimeParams = (
   );
 
 interface wsParams {
+  getwsNarrative: { upa: string };
   getwsObjectByName: { upa: string };
   listObjects: {
     ids?: number[];
@@ -44,6 +46,13 @@ interface wsParams {
 }
 
 interface wsResults {
+  getwsNarrative: {
+    data: {
+      data: {
+        cells: Cell[];
+      };
+    }[];
+  }[];
   getwsObjectByName: unknown;
   listWorkspaceInfo: [
     id: number,
@@ -73,6 +82,16 @@ interface wsResults {
 
 const wsApi = baseApi.injectEndpoints({
   endpoints: (builder) => ({
+    getwsNarrative: builder.query<
+      wsResults['getwsNarrative'],
+      wsParams['getwsNarrative']
+    >({
+      query: ({ upa }) =>
+        ws({
+          method: 'Workspace.get_objects2',
+          params: [{ objects: [{ ref: upa }] }],
+        }),
+    }),
     getwsObjectByName: builder.query<
       wsResults['getwsObjectByName'],
       wsParams['getwsObjectByName']
@@ -106,5 +125,9 @@ const wsApi = baseApi.injectEndpoints({
   }),
 });
 
-export const { getwsObjectByName, listObjects, listWorkspaceInfo } =
-  wsApi.endpoints;
+export const {
+  getwsNarrative,
+  getwsObjectByName,
+  listObjects,
+  listWorkspaceInfo,
+} = wsApi.endpoints;

--- a/src/common/types/NarrativeDoc.tsx
+++ b/src/common/types/NarrativeDoc.tsx
@@ -1,5 +1,11 @@
 import { AppTag } from '../../features/icons/iconSlice';
 
+/*
+ The KBaseCell type does not describe an entire cell, but the contents of the
+ `kbase` key within a CodeCell. It mainly exists to support the type guards
+ used to determine which kind of cell this object represents, that is, an App,
+ Code, Data or other kind of cell.
+*/
 interface KBaseCell {
   attributes: {
     subtitle?: string;
@@ -97,17 +103,6 @@ export interface NarrativeDoc {
   total_cells: number;
   version: number;
 }
-
-// for NarrativeList and children components
-export type NarrativeListDoc = Pick<
-  NarrativeDoc,
-  | 'access_group'
-  | 'creator'
-  | 'narrative_title'
-  | 'obj_id'
-  | 'timestamp'
-  | 'version'
->;
 
 export const isKBaseCodeTypeCell = (
   kbase: KBaseCell

--- a/src/features/navigator/NarrativeList/NarrativeList.fixture.tsx
+++ b/src/features/navigator/NarrativeList/NarrativeList.fixture.tsx
@@ -1,5 +1,39 @@
-import { NarrativeListDoc } from '../../../common/types/NarrativeDoc';
-export const testItems: NarrativeListDoc[] = [
+import { NarrativeDoc } from '../../../common/types/NarrativeDoc';
+
+export type NarrativeTestDoc = Pick<
+  NarrativeDoc,
+  | 'access_group'
+  | 'creator'
+  | 'narrative_title'
+  | 'obj_id'
+  | 'timestamp'
+  | 'version'
+>;
+
+export const factoryNarrativeDoc = (
+  partial: NarrativeTestDoc
+): NarrativeDoc => {
+  return {
+    cells: [],
+    copied: null,
+    creation_date: partial.timestamp.toString(),
+    data_objects: [],
+    is_narratorial: false,
+    is_public: false,
+    is_temporary: false,
+    modified_at: partial.timestamp,
+    obj_name: 'obj_name',
+    obj_type_module: 'KBaseType',
+    obj_type_version: '1',
+    owner: partial.creator,
+    shared_users: [],
+    tags: [],
+    total_cells: 0,
+    ...partial,
+  };
+};
+
+export const testItems: NarrativeDoc[] = [
   {
     access_group: 10000,
     creator: 'user0',
@@ -169,4 +203,4 @@ export const testItems: NarrativeListDoc[] = [
     timestamp: 2147483647501,
     version: 4,
   },
-];
+].map((partial) => factoryNarrativeDoc(partial));

--- a/src/features/navigator/NarrativeList/NarrativeList.tsx
+++ b/src/features/navigator/NarrativeList/NarrativeList.tsx
@@ -1,13 +1,13 @@
 import { FontAwesomeIcon as FAIcon } from '@fortawesome/react-fontawesome';
 import { faCog } from '@fortawesome/free-solid-svg-icons';
 import { Link } from 'react-router-dom';
-import { NarrativeListDoc } from '../../../common/types/NarrativeDoc';
+import { NarrativeDoc } from '../../../common/types/NarrativeDoc';
 import classes from './NarrativeList.module.scss';
 import NarrativeViewItem from './NarrativeViewItem';
 
 interface NarrativeListProps {
   hasMoreItems: boolean;
-  items: Array<NarrativeListDoc>;
+  items: NarrativeDoc[];
   itemsRemaining: number;
   loading: boolean;
   narrativeUPA: string | null;

--- a/src/features/navigator/NarrativeList/NarrativeViewItem.test.tsx
+++ b/src/features/navigator/NarrativeList/NarrativeViewItem.test.tsx
@@ -2,18 +2,13 @@ import { screen, render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { MemoryRouter as Router, Route, Routes } from 'react-router-dom';
 import { createTestStore } from '../../../app/store';
-import { NarrativeListDoc } from '../../../common/types/NarrativeDoc';
+import { testItems } from './NarrativeList.fixture';
 import NarrativeViewItem from './NarrativeViewItem';
 import { narrativeSelectedPath } from '../Navigator';
 
-const testDoc: NarrativeListDoc = {
-  timestamp: 0,
-  access_group: 4000,
-  obj_id: 4000,
-  version: 4000,
-  narrative_title: 'What a cool narrative',
-  creator: 'JaRule',
-};
+const testDoc = testItems[0];
+const { access_group, creator, obj_id, version } = testDoc;
+const testDocUPA = `${access_group}/${obj_id}/${version}`;
 
 test('NarrativeViewItem renders', () => {
   const { container } = render(
@@ -26,16 +21,17 @@ test('NarrativeViewItem renders', () => {
   expect(container).toBeTruthy();
   expect(container.querySelectorAll('.narrative_item_outer')).toHaveLength(1);
   expect(
-    screen.getByText('What a cool narrative', { exact: false })
+    screen.getByText(testDoc.narrative_title, { exact: false })
   ).toBeInTheDocument();
-  expect(screen.getByText('JaRule', { exact: false })).toBeInTheDocument();
-  expect(screen.getByText('cool', { exact: false })).toBeInTheDocument();
+  expect(
+    screen.getByText(`by ${creator}`, { exact: false })
+  ).toBeInTheDocument();
 });
 
 test('NarrativeViewItem displays active class', () => {
   const { container } = render(
     <Provider store={createTestStore()}>
-      <Router initialEntries={[`/narratives/4000/4000/4000`]}>
+      <Router initialEntries={[`/narratives/${testDocUPA}`]}>
         <Routes>
           <Route
             path={narrativeSelectedPath}

--- a/src/features/navigator/NarrativeList/NarrativeViewItem.tsx
+++ b/src/features/navigator/NarrativeList/NarrativeViewItem.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import * as timeago from 'timeago.js';
 import { useAppSelector } from '../../../common/hooks';
-import { NarrativeListDoc } from '../../../common/types/NarrativeDoc';
+import { NarrativeDoc } from '../../../common/types/NarrativeDoc';
 import { getParams } from '../../../features/params/paramsSlice';
 import { narrativePath, navigatorParams } from '../common';
 import { categorySelected } from '../navigatorSlice';
@@ -11,7 +11,7 @@ import classes from './NarrativeList.module.scss';
 
 export interface NarrativeViewItemProps {
   idx: number;
-  item: NarrativeListDoc;
+  item: NarrativeDoc;
   showVersionDropdown: boolean;
   onSelectItem?: (idx: number) => void;
   onUpaChange?: (upa: string) => void;
@@ -23,22 +23,21 @@ const NarrativeViewItem: FC<NarrativeViewItemProps> = ({
   onUpaChange,
   showVersionDropdown,
 }) => {
-  const { access_group, creator, narrative_title, obj_id, timestamp, version } =
-    item;
-  const upa = `${access_group}/${obj_id}/${version}`;
+  const categorySet = useAppSelector(categorySelected);
+  const europaParams = useAppSelector(getParams);
   const {
     id = null,
     obj = null,
     ver = null,
   } = useParams<{ id: string; obj: string; ver: string }>();
+  const { access_group, creator, narrative_title, obj_id, timestamp, version } =
+    item;
+  const upa = `${access_group}/${obj_id}/${version}`;
   const active =
     access_group.toString() === id && obj_id.toString() === obj && ver;
   const status = active ? 'active' : 'inactive';
   // Note: timeago expects milliseconds
   const timeElapsed = timeago.format(timestamp);
-  const categorySet = useAppSelector(categorySelected);
-  const europaParams = useAppSelector(getParams);
-
   function handleVersionSelect(version: number) {
     onUpaChange?.(`${access_group}/${obj_id}/${version}`);
   }

--- a/src/features/navigator/NarrativeView.fixture.tsx
+++ b/src/features/navigator/NarrativeView.fixture.tsx
@@ -204,6 +204,6 @@ export const testNarrative: NarrativeDoc = {
   shared_users: [],
   tags: [],
   timestamp: 0,
-  total_cells: 0,
+  total_cells: testCells.length,
   version: 0,
 };

--- a/src/features/navigator/NarrativeView.test.tsx
+++ b/src/features/navigator/NarrativeView.test.tsx
@@ -1,7 +1,6 @@
 import {
   render,
   // screen
-  // screen
 } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { MemoryRouter as Router } from 'react-router-dom';
@@ -9,6 +8,11 @@ import { createTestStore } from '../../app/store';
 import { NarrativePreviewTemplate } from '../../stories/components/NarrativePreview.stories';
 import NarrativeView from './NarrativeView';
 import { testNarrative } from './NarrativeView.fixture';
+
+const consoleError = jest.spyOn(console, 'error');
+// This mockImplementation supresses console.error calls.
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+consoleError.mockImplementation(() => {});
 
 describe('The <NarrativeView /> component...', () => {
   test('renders.', () => {
@@ -25,6 +29,18 @@ describe('The <NarrativeView /> component...', () => {
 });
 
 describe('The <NarrativePreview /> component...', () => {
+  afterAll(() => {
+    consoleError.mockRestore();
+  });
+
+  afterEach(() => {
+    consoleError.mockClear();
+  });
+
+  beforeEach(() => {
+    consoleError.mockClear();
+  });
+
   test('renders.', () => {
     const { container } = render(
       <Router>
@@ -38,13 +54,23 @@ describe('The <NarrativePreview /> component...', () => {
     expect(container.querySelector('section.preview')).toBeInTheDocument();
   });
 
-  test('renders with more cells.', () => {
+  test('renders with one more cell.', () => {
     const { container } = render(
       <Router>
         <NarrativePreviewTemplate
           wsId={1}
           cells={testNarrative.cells.slice(0, 17)}
         />
+      </Router>
+    );
+    expect(container).toBeTruthy();
+    expect(container.querySelector('section.preview')).toBeInTheDocument();
+  });
+
+  test('renders with more cells.', () => {
+    const { container } = render(
+      <Router>
+        <NarrativePreviewTemplate wsId={1} cells={testNarrative.cells} />
       </Router>
     );
     expect(container).toBeTruthy();

--- a/src/features/navigator/Navigator.tsx
+++ b/src/features/navigator/Navigator.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-router-dom';
 import { Button } from '../../common/components';
 import { useAppDispatch, useAppSelector } from '../../common/hooks';
-import { NarrativeListDoc } from '../../common/types/NarrativeDoc';
+import { NarrativeDoc } from '../../common/types/NarrativeDoc';
 import { authUsername } from '../../features/auth/authSlice';
 import { usePageTitle } from '../../features/layout/layoutSlice';
 import {
@@ -112,7 +112,7 @@ const FilterContainer: FC<{ search: string; sort: string }> = ({
 const MainContainer: FC<{
   limit: number;
   limitTemplate: (limit: number) => string;
-  items: NarrativeListDoc[];
+  items: NarrativeDoc[];
   narrativeUPA: string;
   view: string;
 }> = ({ limit, limitTemplate, items, narrativeUPA, view }) => {
@@ -145,7 +145,7 @@ const searchParamDefaults = {
   sort: Sort['-updated'],
   view: 'data',
 } as const;
-const narrativesByAccessGroup = (narratives: NarrativeListDoc[]) => {
+const narrativesByAccessGroup = (narratives: NarrativeDoc[]) => {
   return Object.fromEntries(
     narratives.map((narrative) => [narrative.access_group, narrative])
   );
@@ -154,7 +154,7 @@ const getNarrativeSelected = (parameters: {
   id: string | undefined;
   obj: string | undefined;
   ver: string | undefined;
-  items: NarrativeListDoc[];
+  items: NarrativeDoc[];
 }) => {
   const { id, obj, ver, items } = parameters;
   const narrativesLookup = narrativesByAccessGroup(items);

--- a/src/features/navigator/navigatorSlice.ts
+++ b/src/features/navigator/navigatorSlice.ts
@@ -1,25 +1,33 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { RootState } from '../../app/store';
-import { NarrativeListDoc } from '../../common/types/NarrativeDoc';
+import {
+  Cell,
+  DataObject,
+  NarrativeDoc,
+} from '../../common/types/NarrativeDoc';
 import { SearchResults } from '../../common/api/searchApi';
 import { Category } from './common';
 
 // Define a type for the slice state
 interface NavigatorState {
   category: Category;
+  cells: Cell[];
   count: number;
-  narratives: NarrativeListDoc[];
+  narratives: NarrativeDoc[];
   search_time: number;
   selected: string | null;
+  wsObjects: Record<number, DataObject[]>;
 }
 
 // Define the initial state using that type
 const initialState: NavigatorState = {
   category: Category['own'],
+  cells: [],
   count: 0,
   narratives: [],
   search_time: 0,
   selected: null,
+  wsObjects: {},
 };
 
 export const navigatorSlice = createSlice({
@@ -33,21 +41,31 @@ export const navigatorSlice = createSlice({
     setCategory: (state, action: PayloadAction<NavigatorState['category']>) => {
       state.category = action.payload;
     },
+    setCells: (state, action: PayloadAction<NavigatorState['cells']>) => {
+      state.cells = action.payload;
+    },
     setNarratives: (
       state,
       action: PayloadAction<SearchResults['getNarratives']>
     ) => {
+      const hits = action.payload.hits;
       state.count = action.payload.count;
-      state.narratives = action.payload.hits;
+      state.narratives = hits;
       state.search_time = action.payload.search_time;
+      hits.forEach(
+        (hit) => (state.wsObjects[hit.access_group] = hit.data_objects)
+      );
     },
   },
 });
 
 export default navigatorSlice.reducer;
-export const { select, setCategory, setNarratives } = navigatorSlice.actions;
+export const { select, setCategory, setCells, setNarratives } =
+  navigatorSlice.actions;
 // Other code such as selectors can use the imported `RootState` type
 export const categorySelected = (state: RootState) => state.navigator.category;
+export const cells = (state: RootState) => state.navigator.cells;
 export const narratives = (state: RootState) => state.navigator.narratives;
 export const narrativeCount = (state: RootState) => state.navigator.count;
 export const navigatorSelected = (state: RootState) => state.navigator.selected;
+export const wsObjects = (state: RootState) => state.navigator.wsObjects;


### PR DESCRIPTION
- [x] URO-149 Connect data and preview views to API
  - [x] Add a narrative object to the navigator slice.
  - [x] Create a hook to load a narrative object by UPA into the state.
  - [x] Create or update the appropriate service API using RTK Query.
  - [x] Write tests with 100% coverage.