### PR TITLE
RE2022-166 RE2022-167 Export

### DIFF
--- a/src/common/api/collectionsApi.ts
+++ b/src/common/api/collectionsApi.ts
@@ -103,6 +103,15 @@ interface CollectionsResults {
   getMatch: Match;
   createSelection: BaseSelection;
   getSelection: Selection;
+  getSelectionTypes: {
+    types: string[];
+  };
+  exportSelection: {
+    set: {
+      upa: string;
+      type: string;
+    };
+  };
   listTaxaCountRanks: { data: string[] };
   getTaxaCountRank: {
     data: {
@@ -146,6 +155,16 @@ interface CollectionsParams {
   };
   getSelection: {
     selection_id: string;
+  };
+  getSelectionTypes: {
+    selection_id: string;
+  };
+  exportSelection: {
+    selection_id: string;
+    workspace_id: string;
+    object_name: string;
+    ws_type: string;
+    description: string;
   };
   listTaxaCountRanks: { collection_id: string; load_ver_override?: string };
   getTaxaCountRank: {
@@ -303,6 +322,38 @@ export const collectionsApi = baseApi.injectEndpoints({
         }),
     }),
 
+    getSelectionTypes: builder.query<
+      CollectionsResults['getSelectionTypes'],
+      CollectionsParams['getSelectionTypes']
+    >({
+      query: ({ selection_id }) =>
+        collectionsService({
+          method: 'GET',
+          url: encode`/selections/${selection_id}/types`,
+          params: {
+            verbose: true,
+          },
+          headers: {
+            authorization: `Bearer ${store.getState().auth.token}`,
+          },
+        }),
+    }),
+
+    exportSelection: builder.mutation<
+      CollectionsResults['exportSelection'],
+      CollectionsParams['exportSelection']
+    >({
+      query: ({ selection_id, workspace_id, object_name, ws_type, ...body }) =>
+        collectionsService({
+          method: 'POST',
+          url: encode`/selections/${selection_id}/toset/${workspace_id}/obj/${object_name}/type/${ws_type}`,
+          body: body,
+          headers: {
+            authorization: `Bearer ${store.getState().auth.token}`,
+          },
+        }),
+    }),
+
     listTaxaCountRanks: builder.query<
       CollectionsResults['listTaxaCountRanks'],
       CollectionsParams['listTaxaCountRanks']
@@ -367,6 +418,8 @@ export const {
   getMatch,
   createSelection,
   getSelection,
+  getSelectionTypes,
+  exportSelection,
   listTaxaCountRanks,
   getTaxaCountRank,
   getGenomeAttribs,

--- a/src/common/api/searchApi.ts
+++ b/src/common/api/searchApi.ts
@@ -11,7 +11,7 @@ interface SearchGetNarrativesParams {
     only_public: boolean;
   };
   filters: {
-    operator: 'AND';
+    operator: 'AND' | 'OR';
     fields: {
       field: string;
       term?: string | boolean;

--- a/src/features/collections/CollectionDetail.tsx
+++ b/src/features/collections/CollectionDetail.tsx
@@ -71,7 +71,7 @@ export const CollectionDetail = () => {
       <div className={styles['collection_detail']}>
         <MatchPane collectionId={collection.id} />
         <SelectionPane collectionId={collection.id} />
-        <ExportPane />
+        <ExportPane collectionId={collection.id} />
       </div>
       <div className={styles['data_products']}>
         <CardList className={styles['data_product_list']}>

--- a/src/features/collections/CollectionDetail.tsx
+++ b/src/features/collections/CollectionDetail.tsx
@@ -8,6 +8,7 @@ import { DataProduct } from './DataProduct';
 import { snakeCaseToHumanReadable } from '../../common/utils/stringUtils';
 import { MatchPane } from './MatchPane';
 import { SelectionPane } from './SelectionPane';
+import { ExportPane } from './ExportPane';
 
 export const detailPath = ':id';
 export const detailDataProductPath = ':id/:data_product';
@@ -70,6 +71,7 @@ export const CollectionDetail = () => {
       <div className={styles['collection_detail']}>
         <MatchPane collectionId={collection.id} />
         <SelectionPane collectionId={collection.id} />
+        <ExportPane />
       </div>
       <div className={styles['data_products']}>
         <CardList className={styles['data_product_list']}>

--- a/src/features/collections/ExportPane.tsx
+++ b/src/features/collections/ExportPane.tsx
@@ -6,12 +6,12 @@ import {
 } from '../../common/api/collectionsApi';
 import { getNarratives } from '../../common/api/searchApi';
 import { Select, Input, Button, SelectOption } from '../../common/components';
-import { useAppSelector } from '../../common/hooks';
 import { uriEncodeTemplateTag as encode } from '../../common/utils/stringUtils';
+import { useSelectionId } from './collectionsSlice';
 import { useParamsForNarrativeDropdown } from './hooks';
 
-export const ExportPane = () => {
-  const selectionId = useAppSelector((state) => state.collections.selection.id);
+export const ExportPane = ({ collectionId }: { collectionId: string }) => {
+  const selectionId = useSelectionId(collectionId);
   const [name, setName] = useState<string>('');
   const [desc, setDesc] = useState<string>('');
   const [narrativeSel, setNarrativeSel] = useState<SelectOption | undefined>();

--- a/src/features/collections/ExportPane.tsx
+++ b/src/features/collections/ExportPane.tsx
@@ -1,0 +1,85 @@
+import { useMemo, useState } from 'react';
+import {
+  exportSelection,
+  getSelectionTypes,
+} from '../../common/api/collectionsApi';
+import { getNarratives } from '../../common/api/searchApi';
+import { Select, Input, Button, SelectOption } from '../../common/components';
+import { useAppSelector } from '../../common/hooks';
+import { useParamsForNarrativeDropdown } from './hooks';
+
+export const ExportPane = () => {
+  const selectionId = useAppSelector((state) => state.collections.selection.id);
+  const [name, setName] = useState<string>('');
+  const [desc, setDesc] = useState<string>('');
+  const [narrativeSel, setNarrativeSel] = useState<SelectOption | undefined>();
+  const [typeSel, setTypeSel] = useState<SelectOption | undefined>();
+  const [narrativeSearch, setNarrativeSearch] = useState('');
+
+  const narrativeSearchParams = useParamsForNarrativeDropdown(narrativeSearch);
+  const narrativeQuery = getNarratives.useQuery(narrativeSearchParams);
+  const narrativeOptions = (narrativeQuery?.data?.hits || []).map((hit) => ({
+    value: [hit.access_group, hit.obj_id, hit.version].join('/'),
+    label: hit.narrative_title,
+    data: hit,
+  }));
+  const narrativeSelected = narrativeOptions.find(
+    (d) => d.value === narrativeSel?.value
+  )?.data;
+
+  const typesParams = useMemo(
+    () => ({ selection_id: selectionId ?? '' }),
+    [selectionId]
+  );
+  const typesResult = getSelectionTypes.useQuery(typesParams, {
+    skip: !selectionId,
+  });
+
+  const [triggerExport, exportResult] = exportSelection.useMutation();
+  const handleExport = () => {
+    if (!complete) return;
+    triggerExport({
+      selection_id: selectionId,
+      workspace_id: narrativeSelected?.access_group.toString(),
+      ws_type: typeSel?.value.toString(),
+      object_name: name,
+      description: desc,
+    });
+  };
+
+  const complete =
+    selectionId && typeSel?.value && narrativeSelected?.access_group && name;
+  return (
+    <>
+      <h3>Save To Narrative</h3>
+      <Select
+        placeholder="Select export type..."
+        disabled={typesResult.isFetching}
+        onChange={(opts) => setTypeSel(opts[0])}
+        options={(typesResult.data?.types ?? []).map((type) => ({
+          value: type,
+          label: type,
+        }))}
+      />
+      <Select
+        placeholder="Select narrative..."
+        onSearch={setNarrativeSearch}
+        onChange={(opts) => setNarrativeSel(opts[0])}
+        options={narrativeOptions}
+      />
+      <Input
+        value={name}
+        onChange={(e) => setName(e.currentTarget.value)}
+        label={<>Object Name</>}
+      />
+      <Input
+        value={desc}
+        onChange={(e) => setDesc(e.currentTarget.value)}
+        label={<>Object description (optional)</>}
+      />
+      <Button disabled={!complete} onClick={handleExport}>
+        Save to Narrative
+      </Button>
+    </>
+  );
+};

--- a/src/features/collections/ExportPane.tsx
+++ b/src/features/collections/ExportPane.tsx
@@ -49,13 +49,13 @@ export const ExportPane = ({ collectionId }: { collectionId: string }) => {
     });
   };
 
-  const exportError = parseCollectionsError(exportResult.error);
-  const exportErrorUnknown = exportResult.error && !exportError;
-  const exportErrorText = exportErrorUnknown
-    ? 'An unknown error occurred while saving to the narrative.'
-    : exportError
-    ? `${exportError.error.httpcode}: ${exportError.error.message}`
-    : undefined;
+  let exportError = '';
+  const parsedErr = parseCollectionsError(exportResult.error);
+  if (parsedErr) {
+    exportError = `${parsedErr.error.httpcode}: ${parsedErr.error.message}`;
+  } else if (exportResult.error) {
+    exportError = 'An unknown error occurred while saving to the narrative.';
+  }
 
   const complete =
     selectionId && typeSel?.value && narrativeSelected?.access_group && name;
@@ -93,7 +93,7 @@ export const ExportPane = ({ collectionId }: { collectionId: string }) => {
       >
         Save to Narrative
       </Button>
-      {exportErrorText ? <p className="">{exportErrorText}</p> : <></>}
+      {exportError ? <p className="">{exportError}</p> : <></>}
       {exportResult.data ? (
         <p className="">
           <strong>Data object created!</strong>

--- a/src/features/collections/MatchPane.tsx
+++ b/src/features/collections/MatchPane.tsx
@@ -31,7 +31,7 @@ const ViewMatch = () => {
   const matchId = useAppParam('match');
   const updateAppParams = useUpdateAppParams();
   const selectionSize = useAppSelector(
-    (state) => state.collections.selection.current.length
+    (state) => state.collections.currentSelection.length
   );
 
   const matchQuery = usePollMatch(matchId);
@@ -50,25 +50,25 @@ const ViewMatch = () => {
   const handleSelectAll = () => {
     if (match?.state !== 'complete') return;
     dispatch(
-      setUserSelection({
-        selection: Array.from(
+      setUserSelection(
+        Array.from(
           new Set([
-            ...store.getState().collections.selection.current,
+            ...store.getState().collections.currentSelection,
             ...match.matches,
           ])
-        ),
-      })
+        )
+      )
     );
   };
   const handleDeselectAll = () => {
     if (match?.state !== 'complete') return;
     const matchSet = new Set(match.matches);
     dispatch(
-      setUserSelection({
-        selection: store
+      setUserSelection(
+        store
           .getState()
-          .collections.selection.current.filter((sel) => !matchSet.has(sel)),
-      })
+          .collections.currentSelection.filter((sel) => !matchSet.has(sel))
+      )
     );
   };
 

--- a/src/features/collections/MatchPane.tsx
+++ b/src/features/collections/MatchPane.tsx
@@ -6,12 +6,14 @@ import {
 import classes from './Collections.module.scss';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Button, Select, SelectOption } from '../../common/components';
-import { listObjects, listWorkspaceInfo } from '../../common/api/workspaceApi';
+import { listObjects } from '../../common/api/workspaceApi';
+import { getNarratives } from '../../common/api/searchApi';
 import { parseError } from '../../common/api/utils/parseError';
 import { useAppParam, useUpdateAppParams } from '../params/hooks';
 import { useAppDispatch, useAppSelector, useBackoff } from '../../common/hooks';
 import { setUserSelection } from './collectionsSlice';
 import { store } from '../../app/store';
+import { useParamsForNarrativeDropdown } from './hooks';
 
 export const MatchPane = ({ collectionId }: { collectionId: string }) => {
   const matchId = useAppParam('match');
@@ -144,16 +146,15 @@ const CreateMatch = ({ collectionId }: { collectionId: string }) => {
   }, [matchers]);
 
   // Narrative selection
+  const [narrativeSearch, setNarrativeSearch] = useState('');
   const [narrativeSel, setNarrativeSel] = useState<SelectOption | undefined>();
-
-  const narrativeQuery = listWorkspaceInfo.useQuery({});
-
-  const narrativeOptions = (narrativeQuery?.data?.[0] || []).map((ws) => ({
-    value: ws[0],
-    label: ws[1],
-    data: ws,
+  const narrativeSearchParams = useParamsForNarrativeDropdown(narrativeSearch);
+  const narrativeQuery = getNarratives.useQuery(narrativeSearchParams);
+  const narrativeOptions = (narrativeQuery?.data?.hits || []).map((hit) => ({
+    value: [hit.access_group, hit.obj_id, hit.version].join('/'),
+    label: hit.narrative_title,
+    data: hit,
   }));
-
   const narrativeSelected = narrativeOptions.find(
     (d) => d.value === narrativeSel?.value
   )?.data;
@@ -162,7 +163,9 @@ const CreateMatch = ({ collectionId }: { collectionId: string }) => {
   const [dataObjSel, setDataObjSel] = useState<SelectOption[]>([]);
 
   const dataObjQuery = listObjects.useQuery({
-    ids: narrativeSelected?.[0] ? [narrativeSelected?.[0]] : [],
+    ids: narrativeSelected?.access_group
+      ? [narrativeSelected?.access_group]
+      : [],
   });
 
   const allTypes = [
@@ -172,7 +175,7 @@ const CreateMatch = ({ collectionId }: { collectionId: string }) => {
 
   const dataObjOptions = (dataObjQuery?.data?.[0] || [])
     .map((objInfo) => ({
-      value: `${narrativeSelected?.[0]}/${objInfo[0]}/${objInfo[4]}`,
+      value: `${narrativeSelected?.access_group}/${objInfo[0]}/${objInfo[4]}`,
       label: objInfo[1],
       data: objInfo,
     }))
@@ -223,6 +226,7 @@ const CreateMatch = ({ collectionId }: { collectionId: string }) => {
         value={narrativeSel}
         options={narrativeOptions}
         loading={narrativeQuery.isFetching}
+        onSearch={setNarrativeSearch}
         onChange={(opt) => {
           setNarrativeSel(opt[0]);
           setDataObjSel([]);

--- a/src/features/collections/SelectionPane.tsx
+++ b/src/features/collections/SelectionPane.tsx
@@ -1,144 +1,36 @@
-import { useAppDispatch, useAppSelector, useBackoff } from '../../common/hooks';
-import { useEffect } from 'react';
-import { FontAwesomeIcon as FAIcon } from '@fortawesome/react-fontawesome';
-import { faSpinner } from '@fortawesome/free-solid-svg-icons';
-import {
-  setPendingSelectionId,
-  setServerSelection,
-  setUserSelection,
-} from './collectionsSlice';
-import { createSelection, getSelection } from '../../common/api/collectionsApi';
+import { useAppDispatch, useAppSelector } from '../../common/hooks';
+import { setUserSelection } from './collectionsSlice';
 import { Button } from '../../common/components';
+import { useEffect } from 'react';
 
 export const SelectionPane = ({ collectionId }: { collectionId: string }) => {
   const dispatch = useAppDispatch();
 
-  const selection = useAppSelector((state) => state.collections.selection);
-  useSyncSelection(collectionId);
+  const currentSelection = useAppSelector(
+    (state) => state.collections.currentSelection
+  );
+  const _verifiedSelectionId = useAppSelector(
+    (state) => state.collections._verifiedSelectionId
+  );
+
+  // Reset selection when collectionId changes
+  useEffect(() => {
+    dispatch(setUserSelection([]));
+  }, [collectionId, dispatch]);
 
   return (
     <>
-      <h3>
-        Selection Options{' '}
-        {selection.pendingId ? <FAIcon icon={faSpinner} spin /> : <></>}
-      </h3>
+      <h3>Selection Options</h3>
       <ul>
         <li>
-          Your current selection includes {selection.current.length} items.
+          Your current selection includes {currentSelection.length} items.
         </li>
-        <li>Selection ID: {selection.id}</li>
-        <li>Selection: {[...selection.current].join(', ')}</li>
+        <li>Selection ID (if processed): {_verifiedSelectionId}</li>
+        <li>Selection: {currentSelection.join(', ')}</li>
       </ul>
-      <Button onClick={() => dispatch(setUserSelection({ selection: [] }))}>
+      <Button onClick={() => dispatch(setUserSelection([]))}>
         Clear Selection
       </Button>
     </>
   );
-};
-
-const useSyncSelection = (collectionId: string) => {
-  const dispatch = useAppDispatch();
-  const selection = useAppSelector((state) => state.collections.selection);
-
-  useEffect(() => {
-    // clear selection when the collection changes
-    dispatch(setUserSelection({ selection: [] }));
-  }, [collectionId, dispatch]);
-
-  // selection creation
-  const [createSelectionMutation, createSelectionResult] =
-    createSelection.useMutation();
-
-  useEffect(() => {
-    // create a new server-side collection when a user has an unsaved collection in state
-    if (!selection.id && !selection.pendingId && selection.current.length > 0) {
-      createSelectionMutation({
-        collection_id: collectionId,
-        selection_ids: selection.current,
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selection.id, selection.pendingId, selection.current]);
-
-  useEffect(() => {
-    // created ID gets stored as pending (so we can check it still matches the current selection)
-    dispatch(setPendingSelectionId(createSelectionResult.data?.selection_id));
-  }, [createSelectionResult.data?.selection_id, dispatch]);
-
-  // get/poll selection using pending ID
-  const backoff = useBackoff();
-  const getSelectionQuery = getSelection.useQuery(
-    { selection_id: selection.pendingId || '' },
-    {
-      skip: !selection.pendingId,
-      pollingInterval: backoff.duration,
-    }
-  );
-
-  useEffect(
-    () => backoff.increment(),
-    [getSelectionQuery.startedTimeStamp, backoff]
-  );
-
-  useEffect(() => {
-    // reset when pending selection ID changes, don't poll if there isn't a pending selection id
-    backoff.reset();
-    backoff.toggle(!!selection.pendingId);
-  }, [backoff, selection.pendingId]);
-
-  useEffect(() => {
-    // end polling on error or when processing is done
-    if (
-      !getSelectionQuery.isFetching &&
-      (getSelectionQuery.isError ||
-        (getSelectionQuery.data &&
-          getSelectionQuery.data.state !== 'processing'))
-    )
-      backoff.toggle(false);
-  }, [
-    backoff,
-    getSelectionQuery.isFetching,
-    getSelectionQuery.isError,
-    getSelectionQuery.data,
-  ]);
-
-  useEffect(() => {
-    // dispatch saved selection or console.error depending on poll result
-    if (!getSelectionQuery.isFetching) {
-      if (
-        getSelectionQuery.data &&
-        getSelectionQuery.data.state === 'complete'
-      ) {
-        dispatch(
-          setServerSelection({
-            id: getSelectionQuery.data.selection_id,
-            selection: getSelectionQuery.data.selection_ids,
-          })
-        );
-        if (selection.pendingId === getSelectionQuery.data.selection_id) {
-          dispatch(setPendingSelectionId(undefined));
-        }
-      } else if (
-        getSelectionQuery.error ||
-        getSelectionQuery.data?.state === 'failed'
-      ) {
-        // eslint-disable-next-line no-console
-        console.error(
-          'An error occurred fetching a selection',
-          getSelectionQuery.data,
-          getSelectionQuery.error,
-          createSelectionResult.data,
-          createSelectionResult.error
-        );
-      }
-    }
-  }, [
-    createSelectionResult.data,
-    createSelectionResult.error,
-    dispatch,
-    getSelectionQuery.data,
-    getSelectionQuery.error,
-    getSelectionQuery.isFetching,
-    selection.pendingId,
-  ]);
 };

--- a/src/features/collections/collectionsSlice.ts
+++ b/src/features/collections/collectionsSlice.ts
@@ -1,77 +1,37 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { useEffect } from 'react';
+import { createSelection, getSelection } from '../../common/api/collectionsApi';
+import { useAppDispatch, useAppSelector, useBackoff } from '../../common/hooks';
 
 interface CollectionState {
-  selection: {
-    id: string | undefined;
-    pendingId: string | undefined;
-    history: string[];
-    current: string[];
-  };
+  currentSelection: string[];
+  _pendingSelectionId?: string;
+  _verifiedSelectionId?: string;
 }
 
 const initialState: CollectionState = {
-  selection: {
-    id: undefined,
-    pendingId: undefined,
-    current: [],
-    history: [],
-  },
+  currentSelection: [],
 };
 
 export const CollectionSlice = createSlice({
   name: 'Collection',
   initialState,
   reducers: {
-    setUserSelection: (
-      state,
-      {
-        payload,
-      }: PayloadAction<{
-        selection: string[];
-      }>
-    ) => {
-      if (payload.selection.length < 1) {
-        // nothing selected, clear
-        // clear but keep history (for debugging atm)
-        state.selection = {
-          ...initialState.selection,
-          history: [
-            ...state.selection.history,
-            state.selection.id ?? '',
-          ].filter(Boolean),
-        };
-        return;
-      }
-
-      if (selectionChanged(state.selection.current, payload.selection)) {
-        if (state.selection.id)
-          state.selection.history.push(state.selection.id);
-        state.selection.id = undefined;
-        state.selection.current = [...payload.selection];
-      }
-    },
-    setServerSelection: (
-      state,
-      {
-        payload,
-      }: PayloadAction<{
-        id: CollectionState['selection']['id'];
-        selection: CollectionState['selection']['current'];
-      }>
-    ) => {
-      if (!selectionChanged(payload.selection, state.selection.current)) {
-        // don't store the server selection id unless it matches the current state and has contents
-        state.selection.id = payload.id;
-      }
+    setSelectionId: (state, { payload }: PayloadAction<string | undefined>) => {
+      state._verifiedSelectionId = payload;
     },
     setPendingSelectionId: (
       state,
       { payload }: PayloadAction<string | undefined>
     ) => {
-      state.selection.pendingId = payload;
+      state._pendingSelectionId = payload;
     },
-    clearSelectionHistory: (state) => {
-      state.selection.history = [];
+    setUserSelection: (state, { payload }: PayloadAction<string[]>) => {
+      if (selectionChanged(state.currentSelection, payload)) {
+        state.currentSelection = [...payload];
+        state._verifiedSelectionId = undefined;
+        state._pendingSelectionId = undefined;
+      }
     },
   },
 });
@@ -80,9 +40,104 @@ const selectionChanged = (list1: string[], list2: string[]) =>
   list1.length !== list2.length || list1.some((upa) => !list2.includes(upa));
 
 export default CollectionSlice.reducer;
-export const {
-  setUserSelection,
-  setServerSelection,
-  clearSelectionHistory,
-  setPendingSelectionId,
-} = CollectionSlice.actions;
+export const { setUserSelection, setSelectionId, setPendingSelectionId } =
+  CollectionSlice.actions;
+
+export const useSelectionId = (
+  collectionId: string,
+  { skip = false }: { skip?: boolean } = {}
+) => {
+  const dispatch = useAppDispatch();
+
+  const currentSelection = useAppSelector(
+    (state) => state.collections.currentSelection
+  );
+  const _verifiedSelectionId = useAppSelector(
+    (state) => state.collections._verifiedSelectionId
+  );
+  const _pendingSelectionId = useAppSelector(
+    (state) => state.collections._pendingSelectionId
+  );
+
+  const [createSelectionMutation, createSelectionResult] =
+    createSelection.useMutation();
+
+  const shouldSkipCreation =
+    skip || _verifiedSelectionId || currentSelection.length < 1;
+
+  useEffect(() => {
+    if (!shouldSkipCreation) {
+      createSelectionMutation({
+        collection_id: collectionId,
+        selection_ids: currentSelection,
+      });
+    }
+  }, [
+    collectionId,
+    createSelectionMutation,
+    currentSelection,
+    shouldSkipCreation,
+  ]);
+
+  useEffect(() => {
+    if (!skip && createSelectionResult.data) {
+      dispatch(setPendingSelectionId(createSelectionResult.data.selection_id));
+    }
+  }, [createSelectionResult, dispatch, skip]);
+
+  const shouldSkipValidation = skip || !_pendingSelectionId;
+
+  // Poll for completed selection
+  const backoff = useBackoff();
+  useEffect(() => {
+    backoff.reset();
+    backoff.toggle(!shouldSkipValidation);
+  }, [shouldSkipValidation, backoff]);
+
+  const getMatchQuery = getSelection.useQuery(
+    { selection_id: _pendingSelectionId || '' },
+    {
+      skip: shouldSkipValidation,
+      pollingInterval: backoff.duration,
+    }
+  );
+
+  useEffect(
+    () => backoff.increment(),
+    [getMatchQuery.startedTimeStamp, backoff]
+  );
+
+  const pollDone =
+    getMatchQuery.error || getMatchQuery.data?.state !== 'processing';
+
+  useEffect(() => {
+    if (pollDone) {
+      backoff.toggle(false);
+      dispatch(setPendingSelectionId(undefined));
+      if (getMatchQuery.data && getMatchQuery.data.state === 'complete') {
+        if (
+          !selectionChanged(currentSelection, getMatchQuery.data.selection_ids)
+        ) {
+          dispatch(setSelectionId(getMatchQuery.data.selection_id));
+        }
+      } else {
+        // eslint-disable-next-line no-console
+        console.error(
+          'Error creating selection',
+          getMatchQuery.error,
+          getMatchQuery.data
+        );
+        dispatch(setSelectionId(undefined));
+      }
+    }
+  }, [
+    backoff,
+    currentSelection,
+    dispatch,
+    getMatchQuery.data,
+    getMatchQuery.error,
+    pollDone,
+  ]);
+
+  return _verifiedSelectionId;
+};

--- a/src/features/collections/data_products/TaxaCount.tsx
+++ b/src/features/collections/data_products/TaxaCount.tsx
@@ -4,9 +4,10 @@ import {
   listTaxaCountRanks,
 } from '../../../common/api/collectionsApi';
 import { Select, SelectOption } from '../../../common/components/Select';
-import { useAppSelector, useBackoff } from '../../../common/hooks';
+import { useBackoff } from '../../../common/hooks';
 import { snakeCaseToHumanReadable } from '../../../common/utils/stringUtils';
 import { useAppParam } from '../../params/hooks';
+import { useSelectionId } from '../collectionsSlice';
 import classes from './TaxaCount.module.scss';
 
 export const TaxaCount: FC<{
@@ -28,9 +29,7 @@ export const TaxaCount: FC<{
 
   // Counts
   const matchId = useAppParam('match');
-  const selectionId = useAppSelector((state) => state.collections.selection.id);
-  const hasSelection =
-    useAppSelector((state) => state.collections.selection.current.length) > 0;
+  const selectionId = useSelectionId(collection_id);
   const countsParams = useMemo(
     () => ({
       collection_id,
@@ -86,7 +85,7 @@ export const TaxaCount: FC<{
               ) : (
                 <></>
               )}
-              {hasSelection ? (
+              {selectionId ? (
                 <div className={classes['sub-name']}>Selected</div>
               ) : (
                 <></>
@@ -112,7 +111,7 @@ export const TaxaCount: FC<{
                 ) : (
                   <></>
                 )}
-                {hasSelection ? (
+                {selectionId ? (
                   <Bar
                     className={classes['selected']}
                     width={selWidth}

--- a/src/features/collections/hooks.ts
+++ b/src/features/collections/hooks.ts
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+import { getNarratives } from '../../common/api/searchApi';
+import { useAppSelector } from '../../common/hooks';
+
+export const useParamsForNarrativeDropdown = (query: string) => {
+  const username = useAppSelector((state) => state.auth.username);
+  return useMemo<Parameters<typeof getNarratives.useQuery>[0]>(
+    () => ({
+      access: {
+        only_public: false,
+      },
+      filters: {
+        operator: 'OR',
+        fields: [
+          {
+            field: 'owner',
+            term: username,
+          },
+          {
+            field: 'shared_users',
+            term: username,
+          },
+          {
+            field: 'is_narratorial',
+            term: true,
+          },
+        ],
+      },
+      paging: {
+        length: 30,
+        offset: 0,
+      },
+      search: {
+        query: query ? query : '*',
+        fields: ['agg_fields'],
+      },
+      sorts: [
+        ['timestamp', 'desc'],
+        ['_score', 'desc'],
+      ],
+      types: ['KBaseNarrative.Narrative'],
+    }),
+    [query, username]
+  );
+};


### PR DESCRIPTION
- [Add basic export pane, api endpoints](https://github.com/kbase/ui-refresh-test/pull/77/commits/2c0417b657e3644827d9b60ba7332e1b46adb24b)
- [Use new+better narrative select in matching pane](https://github.com/kbase/ui-refresh-test/pull/77/commits/959e45a05109b44928cb4c505de6edc339eed690)
  - with the help of @dakotablair narrative selects are now way more usable

- [Display links to export results, and show export errors](https://github.com/kbase/ui-refresh-test/pull/77/commits/64504848912fcb68bc2e028c0c4d8f4a4955ab29)

- [Refactor selection to only create server selection when useSelectionI…](https://github.com/kbase/ui-refresh-test/pull/77/commits/468b6e6470fe73c21469255a9933e32bd8120d6e)
  - as noted by @MrCreosote, creating a selection for every change is overkill. This commit adds a hook and new serverside-selection-creation logic to only create an ID when a component using the `useSelectionId` hook is mounted
