### PR TITLE
  RE2022-173 Add microtrait API methods and useMicrotrait table hook stub

### DIFF
--- a/src/features/collections/CollectionDetail.tsx
+++ b/src/features/collections/CollectionDetail.tsx
@@ -9,6 +9,8 @@ import { snakeCaseToHumanReadable } from '../../common/utils/stringUtils';
 import { MatchPane } from './MatchPane';
 import { SelectionPane } from './SelectionPane';
 import { ExportPane } from './ExportPane';
+import { useMicrotrait } from './hooks'; /*temp*/
+import { Table } from '../../common/components/Table'; /*temp*/
 
 export const detailPath = ':id';
 export const detailDataProductPath = ':id/:data_product';
@@ -45,6 +47,8 @@ export const CollectionDetail = () => {
     location.search,
   ]);
 
+  const mt = useMicrotrait(collection?.id); /*temp*/
+
   if (!collection) return <>loading...</>;
   return (
     <div className={styles['collection_wrapper']}>
@@ -69,6 +73,7 @@ export const CollectionDetail = () => {
         </ul>
       </div>
       <div className={styles['collection_detail']}>
+        <Table table={mt.table} /> {/*temp*/}
         <MatchPane collectionId={collection.id} />
         <SelectionPane collectionId={collection.id} />
         <ExportPane collectionId={collection.id} />

--- a/src/features/collections/hooks.ts
+++ b/src/features/collections/hooks.ts
@@ -1,6 +1,19 @@
-import { useMemo } from 'react';
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  getPaginationRowModel,
+  useReactTable,
+  PaginationState,
+} from '@tanstack/react-table';
+import { useMemo, useState } from 'react';
+import {
+  getMicroTrait,
+  getMicroTraitMeta,
+} from '../../common/api/collectionsApi';
 import { getNarratives } from '../../common/api/searchApi';
 import { useAppSelector } from '../../common/hooks';
+import { useAppParam } from '../params/hooks';
+import { useSelectionId } from './collectionsSlice';
 
 export const useParamsForNarrativeDropdown = (query: string) => {
   const username = useAppSelector((state) => state.auth.username);
@@ -42,4 +55,103 @@ export const useParamsForNarrativeDropdown = (query: string) => {
     }),
     [query, username]
   );
+};
+
+// Microtrait hook stub, temporary, for figuring out all the types
+export const useMicrotrait = (collection_id: string | undefined) => {
+  const matchId = useAppParam('match');
+  const selId = useSelectionId(collection_id || '', {
+    skip: !collection_id,
+  });
+  const [matchMark, setMatchMark] = useState<boolean>(true);
+  const [selMark, setSelMark] = useState<boolean>(true);
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 8,
+  });
+
+  const heatMapParams = useMemo(
+    () => ({
+      collection_id: collection_id ?? '',
+      ...(matchId ? { match_id: matchId, match_mark: matchMark } : {}),
+      ...(selId ? { selection_id: selId, selection_mark: selMark } : {}),
+    }),
+    [collection_id, matchId, matchMark, selId, selMark]
+  );
+  const countParams = useMemo(
+    () => ({ ...heatMapParams, count: true }),
+    [heatMapParams]
+  );
+  const metaParams = useMemo(
+    () => ({ collection_id: collection_id ?? '' }),
+    [collection_id]
+  );
+
+  const { data: heatmap, ...heatmapQuery } = getMicroTrait.useQuery(
+    heatMapParams,
+    { skip: !collection_id }
+  );
+
+  const { data: count, ...countQuery } = getMicroTrait.useQuery(countParams, {
+    skip: !collection_id,
+  });
+
+  const { data: meta, ...metaQuery } = getMicroTraitMeta.useQuery(metaParams, {
+    skip: !collection_id,
+  });
+
+  type RowDatum = NonNullable<typeof heatmap>['data'][number];
+
+  const cols = createColumnHelper<RowDatum>();
+
+  const colIndex = Object.fromEntries(
+    meta?.categories
+      .flatMap(({ columns }) => columns.map(({ id }) => id))
+      .map((id, index) => [id, index]) || []
+  );
+
+  const table = useReactTable<RowDatum>({
+    data: heatmap?.data || [],
+    getRowId: (row) => String(row.kbase_id),
+    columns:
+      meta?.categories.map((category) =>
+        cols.group({
+          header: category.category,
+          columns: category.columns.map((col) =>
+            cols.accessor((row) => row.cells[colIndex[col.id]].val, {
+              header: col.name,
+              id: col.id,
+              meta: col,
+            })
+          ),
+        })
+      ) || [],
+
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    enableSorting: false,
+
+    manualPagination: true,
+    pageCount: Math.ceil((count?.count || 0) / pagination.pageSize),
+    onPaginationChange: setPagination,
+
+    enableRowSelection: false,
+
+    state: {
+      pagination,
+    },
+  });
+
+  return {
+    setMatchMark,
+    setSelMark,
+    setPagination,
+    heatmap,
+    heatmapQuery,
+    count,
+    countQuery,
+    meta,
+    metaQuery,
+    table,
+  };
 };


### PR DESCRIPTION
Merging into `microtrait-all` (should I use `feature/microtrait`?) so I can keep microtrait things isolated from `main` for now. Also allows for a final review of `microtrait-all` before merging if we want.

see https://kbase-jira.atlassian.net/browse/RE2022-173 for ACs etc.